### PR TITLE
Fix overflow error in token item

### DIFF
--- a/Samples~/Solana Wallet/Scripts/example/simple_screen_manager/utility/TokenItem.cs
+++ b/Samples~/Solana Wallet/Scripts/example/simple_screen_manager/utility/TokenItem.cs
@@ -44,7 +44,7 @@ namespace Solana.Unity.SDK.Example
         {
             _parentScreen = screen;
             TokenAccount = tokenAccount;
-            if (nftData != null && int.Parse(tokenAccount.Account.Data.Parsed.Info.TokenAmount.Amount) == 1)
+            if (nftData != null && ulong.Parse(tokenAccount.Account.Data.Parsed.Info.TokenAmount.Amount) == 1)
             {
                 await UniTask.SwitchToMainThread();
                 _nft = nftData;


### PR DESCRIPTION
Bug: When loading NFTs in the example the webgl version would freeze. 
Solution: There was a token amount parsed into an int but the amount can be bigger than int. 
