### PR TITLE
:sparkles: Add more wallet restore options

### DIFF
--- a/Runtime/codebase/WalletBase.cs
+++ b/Runtime/codebase/WalletBase.cs
@@ -94,7 +94,6 @@ namespace Solana.Unity.SDK
         /// <inheritdoc />
         public async Task<Account> CreateAccount(string mnemonic = null, string password = null)
         {
-            Mnemonic = new Mnemonic(mnemonic);
             Account = await _CreateAccount(mnemonic, password);
             return Account;
         }

--- a/Runtime/codebase/Web3.cs
+++ b/Runtime/codebase/Web3.cs
@@ -160,7 +160,7 @@ namespace Solana.Unity.SDK
         
         public void Logout()
         {
-            Wallet.Logout();
+            Wallet?.Logout();
             Wallet = null;
         }
 


### PR DESCRIPTION
# Add more wallet restore options

| Status  | Type  | ⚠️ Core Change | Issue |
| :---: | :---: | :---: | :--: |
| Ready | Feature  |  No | - |

## Problem

Previously it was only possible to restore a wallet from mnemonics

## Solution

Added more restore options, available methods include:
- Mnemonics words
- Bip39 private key 
- Secret byte array