### PR TITLE
:sparkles: Add option to keep sms connection alive

### DIFF
--- a/Runtime/codebase/SolanaMobileWalletAdapter.cs
+++ b/Runtime/codebase/SolanaMobileWalletAdapter.cs
@@ -122,6 +122,12 @@ namespace Solana.Unity.SDK
             return Transaction.Deserialize(res.SignedPayloads[0]);
         }
 
+        public override void Logout()
+        {
+            base.Logout();
+            PlayerPrefs.DeleteKey("pk");
+        }
+
         public override async Task<byte[]> SignMessage(byte[] message)
         {
             if (_authToken.IsNullOrEmpty())

--- a/Runtime/codebase/SolanaMobileWalletAdapter.cs
+++ b/Runtime/codebase/SolanaMobileWalletAdapter.cs
@@ -21,6 +21,7 @@ namespace Solana.Unity.SDK
         public string identityUri = "https://solana.unity-sdk.gg/";
         public string iconUri = "/favicon.ico";
         public string name = "Solana.Unity-SDK";
+        public bool keepConnectionAlive = true;
     }
     
     
@@ -52,6 +53,11 @@ namespace Solana.Unity.SDK
 
         protected override async Task<Account> _Login(string password = null)
         {
+            if (_walletOptions.keepConnectionAlive)
+            {
+                string pk = PlayerPrefs.GetString("pk", null);
+                if (pk != null) return new Account(string.Empty, new PublicKey(pk));
+            }
             AuthorizationResult authorization = null;
             var localAssociationScenario = new LocalAssociationScenario();
             var cluster = RPCNameMap[(int)RpcCluster];
@@ -74,6 +80,10 @@ namespace Solana.Unity.SDK
             }
             _authToken = authorization.AuthToken;
             var publicKey = new PublicKey(authorization.PublicKey);
+            if (_walletOptions.keepConnectionAlive)
+            {
+                PlayerPrefs.SetString("pk", publicKey.ToString());
+            }
             return new Account(string.Empty, publicKey);
         }
 


### PR DESCRIPTION
> ⚠️ NOTE: Use notes like this to emphasize something important about the PR.
>  
>  This could include other PRs this PR is built on top of; API breaking changes; reasons for why the PR is on hold; or anything else you would like to draw attention to.

| Status  | Type  | ⚠️ Core Change | Issue |
| :---: | :---: | :---: | :--: |
| Ready | Feature | No | - |

## Problem

As reported on Discord from `BlackDemonZyT`

```
Hello there, im having a problem, im using this line of code to let user link their mobile wallets:

WalletBase wallet = new SolanaMobileWalletAdapter(new SolanaMobileWalletAdapterOptions(), RpcCluster.MainNet, null, null, true);

But every time i do that line of code, the phantom wallet opens asking to accept linking, why, the user already accepted it, shouldnt this line of code just return me the Account next times?
```


## Solution

Save the public key in the player pref and use it if available. Set this behaviour as default, plus a configuration parameter in the wallet option