### PR TITLE
:bug:  Fix HyperlinkXNFT  undefined for non WebGL builds #111

### DIFF
--- a/Runtime/Plugins/HyperlinkXNFT/HyperlinkXnft.cs
+++ b/Runtime/Plugins/HyperlinkXNFT/HyperlinkXnft.cs
@@ -5,20 +5,22 @@ using UnityEngine;
 
 public class HyperlinkXnft : MonoBehaviour
 {
-
-    [DllImport("__Internal")]
-    private static extern void HyperlinkXNFT(string linkUrl);
+   
 
     public void OpenLink(string link)
     {
-        //xnft link has to start with https:// and not have "www" after it. Very important!
-    #if UNITY_EDITOR
         Application.OpenURL(link);
-    #else
-        Application.OpenURL(link);
-        HyperlinkXNFT(link);
-    #endif
+        #if UNITY_WEBGL && !UNITY_EDITOR
+            //xnft link has to start with https:// and not have "www" after it. Very important!
+            HyperlinkXNFT(link);
+        #endif
     }
-
+    
+    #if UNITY_WEBGL
+            [DllImport("__Internal")]
+            private static extern void HyperlinkXNFT(string linkUrl);
+    #else
+        private static void HyperlinkXNFT(string linkUrl){}
+    #endif
 
 }


### PR DESCRIPTION


| Status  | Type  | ⚠️ Core Change | Issue |
| :---: | :---: | :---: | :--: |
| Ready| Bug/Hotfix | Yes | [Link](https://github.com/magicblock-labs/Solana.Unity-SDK/issues/111) |

## Problem

_HyperlinkXNFT not defined for any platform that is not WebGL_


## Solution

_Declare empty function when not WebGL to prevent errors. Also changed IF/ELSE to make it more readable_
