### PR TITLE
:sparkles: Add option to change disable default nfts loading

### DIFF
--- a/Runtime/codebase/Web3.cs
+++ b/Runtime/codebase/Web3.cs
@@ -40,7 +40,7 @@ namespace Solana.Unity.SDK
                 {
                     OnLogin?.Invoke(value.Account);
                     UpdateBalance().Forget();
-                    if(OnNFTsUpdateInternal != null) UpdateNFTs().Forget();
+                    if(OnNFTsUpdateInternal != null && AutoLoadNfts) UpdateNFTs().Forget();
                     SubscribeToWalletEvents().Forget();
                 }
                 if(currentWallet != null && value == null) OnLogout?.Invoke();
@@ -109,10 +109,12 @@ namespace Solana.Unity.SDK
                 OnNFTsUpdateInternal += value;
                 if(Wallet == null) return;
                 OnNFTsUpdateInternal?.Invoke(_nfts, _nfts.Count);
-                UpdateNFTs().Forget();
+                if(AutoLoadNfts) UpdateNFTs().Forget();
             }
             remove => OnNFTsUpdateInternal -= value;
         }
+        public static bool? LoadNftsTextureByDefault = null;
+        public static bool AutoLoadNfts = true;
 
         #endregion
 
@@ -320,6 +322,7 @@ namespace Solana.Unity.SDK
             bool notifyRegisteredListeners = false,
             Commitment commitment = Commitment.Confirmed)
         {
+            loadTexture = LoadNftsTextureByDefault ?? loadTexture;
             if(Wallet == null) return null;
             var tokens = (await Wallet.GetTokenAccounts(commitment))?
                 .ToList()

--- a/Runtime/codebase/Web3.cs
+++ b/Runtime/codebase/Web3.cs
@@ -319,7 +319,7 @@ namespace Solana.Unity.SDK
         /// <param name="commitment"></param>
         public static async UniTask<List<Nft.Nft>> LoadNFTs(
             bool loadTexture = true, 
-            bool notifyRegisteredListeners = false,
+            bool notifyRegisteredListeners = true,
             Commitment commitment = Commitment.Confirmed)
         {
             loadTexture = LoadNftsTextureByDefault ?? loadTexture;


### PR DESCRIPTION
# Add option to change disable default nfts loading

| Status  | Type  | ⚠️ Core Change | Issue |
| :---: | :---: | :---: | :--: |
| Ready | Feature  | No | - |

## Problem

Nfts are loaded by default when registering, this may not always be desired.

## Solution

Added to boolean to change the default configuration.

1. `Web.LoadNftsTextureByDefault` change the loading mechanism to only retrieve NFT metadata.


```csharp
    private void OnEnable()
    {
        Web3.LoadNftsTextureByDefault = false;
        Web3.OnNFTsUpdate += OnNFTsUpdate;
    }
    
    private void OnDisable()
    {
        Web3.OnNFTsUpdate -= OnNFTsUpdate;
    }

    private void OnNFTsUpdate(List<Nft> nfts, int total)
    {
       // Nfts won't have the textures
    }
```

2.  `Web.AutoLoadNfts` disable the auto loading after the login, it can still be triggered manually calling  LoadNFTs:
 ```csharp
 await Web3.LoadNFTs(loadTexture: false);
```