### PR TITLE
NFT Loading GIF Support

### DIFF
--- a/Runtime/Plugins/HyperlinkXNFT/HyperlinkXNFT.jslib
+++ b/Runtime/Plugins/HyperlinkXNFT/HyperlinkXNFT.jslib
@@ -3,6 +3,6 @@ mergeInto(LibraryManager.library, {
 	{
 		url = UTF8ToString(linkUrl);
     	console.log('Opening link: ' + url);
-		window.open(url);
+		window.open(url,'_blank');
 	}
 });

--- a/Runtime/Plugins/HyperlinkXNFT/HyperlinkXNFT.jslib
+++ b/Runtime/Plugins/HyperlinkXNFT/HyperlinkXNFT.jslib
@@ -3,6 +3,6 @@ mergeInto(LibraryManager.library, {
 	{
 		url = UTF8ToString(linkUrl);
     	console.log('Opening link: ' + url);
-		window.xnft.openWindow(url);
+		window.open(url);
 	}
 });

--- a/Runtime/Plugins/HyperlinkXNFT/HyperlinkXNFT.jslib
+++ b/Runtime/Plugins/HyperlinkXNFT/HyperlinkXNFT.jslib
@@ -1,0 +1,8 @@
+mergeInto(LibraryManager.library, {
+	HyperlinkXNFT : function(linkUrl)
+	{
+		url = UTF8ToString(linkUrl);
+    	console.log('Opening link: ' + url);
+		window.xnft.openWindow(url);
+	}
+});

--- a/Runtime/Plugins/HyperlinkXNFT/HyperlinkXNFT.jslib.meta
+++ b/Runtime/Plugins/HyperlinkXNFT/HyperlinkXNFT.jslib.meta
@@ -1,0 +1,32 @@
+fileFormatVersion: 2
+guid: c8c74178128e4d14ca71cd1e85c2140d
+PluginImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  iconMap: {}
+  executionOrder: {}
+  defineConstraints: []
+  isPreloaded: 0
+  isOverridable: 0
+  isExplicitlyReferenced: 0
+  validateReferences: 1
+  platformData:
+  - first:
+      Any: 
+    second:
+      enabled: 0
+      settings: {}
+  - first:
+      Editor: Editor
+    second:
+      enabled: 0
+      settings:
+        DefaultValueInitialized: true
+  - first:
+      WebGL: WebGL
+    second:
+      enabled: 1
+      settings: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/Plugins/HyperlinkXNFT/WebLink.cs
+++ b/Runtime/Plugins/HyperlinkXNFT/WebLink.cs
@@ -1,0 +1,52 @@
+using System.Collections;
+using System.Collections.Generic;
+using System.Runtime.InteropServices;
+using UnityEngine;
+
+public class WebLink : MonoBehaviour
+{
+    public string linkUrl;
+
+    [DllImport("__Internal")]
+    private static extern void HyperlinkXNFT(string linkUrl);
+    // Start is called before the first frame update
+    void Start()
+    {
+        
+    }
+
+    public void OpenLink(string customLink = "")
+    {
+        if(customLink.Length==0)
+            Application.OpenURL(linkUrl);
+        else
+            Application.OpenURL(customLink);
+    }
+
+    public void OpenLinkXNFT(string customLink = "")
+    {
+        //xnft link has to start with https:// and not have "www" after it. Very important!
+    #if UNITY_EDITOR
+            OpenLink(customLink);
+    #else
+            if (customLink.Length == 0)
+                HyperlinkXNFT(linkUrl);
+            else
+                HyperlinkXNFT(customLink);
+    #endif
+    }
+
+    public void OpenDeepLink(string customLink = "")
+    {
+    #if UNITY_IOS || UNITY_ANROID
+                string refUrl = UnityWebRequest.EscapeURL("SolPlay");
+                string escapedUrl = UnityWebRequest.EscapeURL(url);
+                string inWalletUrl = $"https://phantom.app/ul/browse/{url}?ref=solplay";
+    #else
+            string inWalletUrl = (customLink.Length==0) ? linkUrl : customLink;
+    #endif
+            Application.OpenURL(inWalletUrl);
+    }
+
+
+}

--- a/Runtime/Plugins/HyperlinkXNFT/WebLink.cs.meta
+++ b/Runtime/Plugins/HyperlinkXNFT/WebLink.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 882d26f261952cd448e600e58bd3009a
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
> ⚠️ NOTE: Use notes like this to emphasize something important about the PR.
>  
>  This could include other PRs this PR is built on top of; API breaking changes; reasons for why the PR is on hold; or anything else you would like to draw attention to.

| Status  | Type  | ⚠️ Core Change | Issue |
| :---: | :---: | :---: | :--: |
| Ready/Hold | Feature/Bug/Tooling/Refactor/Hotfix | Yes/No | [Link](<Issue link here>) |

## Problem

Gifs are not being loaded by NFT loader


## Solution

Using Solplay Jonas code, I added gif support. Its turns gif into bunch of textures and selects one as the NFT visual


## Other changes (e.g. bug fixes, small refactors)
Changed jslib for opening links within xnft to window.open caust window.xnft.opennwindow is obsolete


**New dependencies**:

gif encoder package is now needed, didnt add it myself
