### PR TITLE
:sparkles: Enhance NFT loading

### DIFF
--- a/Runtime/codebase/Web3.cs
+++ b/Runtime/codebase/Web3.cs
@@ -370,7 +370,7 @@ namespace Solana.Unity.SDK
                     if (Application.platform == RuntimePlatform.WebGLPlayer)
                     {
                         // If we are on WebGL, we need to add a min delay between requests
-                        requestsMillisecondsDelay = Mathf.Max(requestsMillisecondsDelay, 300);
+                        requestsMillisecondsDelay = Mathf.Max(requestsMillisecondsDelay, 100);
                     }
                     if (requestsMillisecondsDelay > 0) await UniTask.Delay(requestsMillisecondsDelay);
 

--- a/Runtime/codebase/nft/Nft.cs
+++ b/Runtime/codebase/nft/Nft.cs
@@ -100,7 +100,6 @@ namespace Solana.Unity.SDK.Nft
         /// <summary>
         /// Load the texture of the NFT
         /// </summary>
-        /// <param name="nft"></param>
         /// <param name="imageHeightAndWidth"></param>
         public async Task LoadTexture(int imageHeightAndWidth = 256)
         {


### PR DESCRIPTION
# Enhance NFT loading & Bug Fixes

| Status  | Type  | ⚠️ Core Change | Issue |
| :---: | :---: | :---: | :--: |
| Ready| Enhance/Bug | No | -|

## Problem

- Nfts loading failing with most RPCs due to rate limit
- Due to a bug in Unity, Destroy was triggering an exception if exiting from play mode while the NFTs are still loading
- Unused LoadJson method
- sNFT were not displayed due to the check on amount == 1

## Solution

- Add a parameter to add a delay between calls (This is a temporary solution and will be superseded by #120 )
- Add a Destroy with uses DestroyImmediate if the game is not running
- Remove unused methods
- Remove amount == 1 check
