### PR TITLE
Fix xNFT sign message issue.

### DIFF
--- a/Runtime/Plugins/SolanaWalletAdapterWebGL/SolanaWalletAdapterWebGL.jslib
+++ b/Runtime/Plugins/SolanaWalletAdapterWebGL/SolanaWalletAdapterWebGL.jslib
@@ -71,7 +71,7 @@ mergeInto(LibraryManager.library, {
                  if(walletName === 'XNFT'){  
                   const messageBytes = Uint8Array.from(atob(base64Message), (c) => c.charCodeAt(0));
                   const signedMessage = await window.xnft.solana.signMessage(messageBytes);
-                  signatureStr = signedMessage.toString('base64');
+                  signatureStr = btoa(String.fromCharCode(...signedMessage));
                 } else {
                     var signature = await window.walletAdapterLib.signMessage(walletName, atob(base64Message));
                     signatureStr =  signature.toString('base64');


### PR DESCRIPTION
> ⚠️ NOTE: Use notes like this to emphasize something important about the PR.
>  
>  This could include other PRs this PR is built on top of; API breaking changes; reasons for why the PR is on hold; or anything else you would like to draw attention to.

| Status  | Type  | ⚠️ Core Change | Issue |
| :---: | :---: | :---: | :--: |
| Ready| Hotfix | No | [Link](#119 ) |

## Problem

xNFT Sign Message never return anything.


## Solution

xNFT Sign Message returns byte array already, so we just needed to convert it to base64, but not like you fixed it, it still did not work.

Instead of using signedMessage.toString('base64'); I've changed it to btoa(String.fromCharCode(...signedMessage));

Now I've tested it and it works as intended.
