### PR TITLE
Fix session refund and account being null when session isn't valid

### DIFF
--- a/Runtime/codebase/IWalletBase.cs
+++ b/Runtime/codebase/IWalletBase.cs
@@ -82,7 +82,7 @@ namespace Solana.Unity.SDK
         /// </summary>
         /// <param name="commitment"></param>
         /// <returns></returns>
-        Task<TokenAccount[]> GetTokenAccounts(Commitment commitment = Commitment.Finalized);
+        Task<TokenAccount[]> GetTokenAccounts(Commitment commitment = Commitment.Confirmed);
 
         /// <summary>
         /// Sign a transaction

--- a/Runtime/codebase/WalletBase.cs
+++ b/Runtime/codebase/WalletBase.cs
@@ -108,14 +108,14 @@ namespace Solana.Unity.SDK
         protected abstract Task<Account> _CreateAccount(string mnemonic = null, string password = null);
 
         /// <inheritdoc />
-        public async Task<double> GetBalance(PublicKey publicKey, Commitment commitment = Commitment.Finalized)
+        public async Task<double> GetBalance(PublicKey publicKey, Commitment commitment = Commitment.Confirmed)
         {
             var balance= await ActiveRpcClient.GetBalanceAsync(publicKey, commitment);
             return (double)(balance.Result?.Value ?? 0) / SolLamports;
         }
 
         /// <inheritdoc />
-        public async Task<double> GetBalance(Commitment commitment = Commitment.Finalized)
+        public async Task<double> GetBalance(Commitment commitment = Commitment.Confirmed)
         {
             return await GetBalance(Account.PublicKey, commitment);
         }
@@ -125,7 +125,7 @@ namespace Solana.Unity.SDK
             PublicKey destination,
             PublicKey tokenMint,
             ulong amount,
-            Commitment commitment = Commitment.Finalized)
+            Commitment commitment = Commitment.Confirmed)
         {
             var sta = AssociatedTokenAccountProgram.DeriveAssociatedTokenAccount(
                 Account.PublicKey,
@@ -159,7 +159,7 @@ namespace Solana.Unity.SDK
 
         /// <inheritdoc />
         public async Task<RequestResult<string>> Transfer(PublicKey destination, ulong amount,
-            Commitment commitment = Commitment.Finalized)
+            Commitment commitment = Commitment.Confirmed)
         {
             var transaction = new Transaction
             {
@@ -190,7 +190,7 @@ namespace Solana.Unity.SDK
         }
 
         /// <inheritdoc />
-        public async Task<TokenAccount[]> GetTokenAccounts(Commitment commitment = Commitment.Finalized)
+        public async Task<TokenAccount[]> GetTokenAccounts(Commitment commitment = Commitment.Confirmed)
         {
             var rpc = ActiveRpcClient;
             var result = await
@@ -248,7 +248,7 @@ namespace Solana.Unity.SDK
         (
             Transaction transaction,
             bool skipPreflight = false,
-            Commitment commitment = Commitment.Finalized)
+            Commitment commitment = Commitment.Confirmed)
         {
             var signedTransaction = await SignTransaction(transaction);
             return await ActiveRpcClient.SendTransactionAsync(
@@ -265,7 +265,7 @@ namespace Solana.Unity.SDK
         /// <param name="amount">Amount of sol</param>
         /// <param name="commitment"></param>
         /// <returns>Amount of sol</returns>
-        public async Task<RequestResult<string>> RequestAirdrop(ulong amount = SolLamports, Commitment commitment = Commitment.Finalized)
+        public async Task<RequestResult<string>> RequestAirdrop(ulong amount = SolLamports, Commitment commitment = Commitment.Confirmed)
         {
             return await ActiveRpcClient.RequestAirdropAsync(Account.PublicKey, amount, commitment); ;
         }


### PR DESCRIPTION

| Status  | Type  | ⚠️ Core Change | 
| :---: | :---: | :---: | :--: |
| Ready|Bug|No | 

## Problem

_What problem are you trying to solve?_
Session wallet would not handle expired session and refunds where not working. 

## Solution

_How did you solve the problem?_
- First problem was that refund was getting a confirmed block hash but was sending with finalzed blockhash. This led the transaction to fail so the players never got their sol back. Fixed by changing send transaction default to confirmed
- Somtimes the refund transaction would fail, since GetBalance would get the finalized balance which let to it being out of date, so the calulation was wrong. Also added a buffer of 5000 lamports in case there is another transaction still running during the confirmation
- Session wallet would return a null account in case that the session account i null or when session is invalid on start. Fixed by calling the function again.

