### PR TITLE
:sparkles: Add rate limiter

### DIFF
--- a/Runtime/codebase/UnityRateLimiter.cs
+++ b/Runtime/codebase/UnityRateLimiter.cs
@@ -20,7 +20,7 @@ namespace Solana.Unity.SDK
           _hitList = new Queue<DateTime>();
         }
     
-        public static UnityRateLimiter Create() => new UnityRateLimiter(1, 0);
+        public static UnityRateLimiter Create() => new UnityRateLimiter(30, 1000);
     
         public bool CanFire()
         {

--- a/Runtime/codebase/UnityRateLimiter.cs
+++ b/Runtime/codebase/UnityRateLimiter.cs
@@ -1,0 +1,73 @@
+using System;
+using System.Collections.Generic;
+using Cysharp.Threading.Tasks;
+using Solana.Unity.Rpc.Utilities;
+
+// ReSharper disable once CheckNamespace
+
+namespace Solana.Unity.SDK
+{
+    public class UnityRateLimiter : IRateLimiter
+      {
+        private int _hits;
+        private int _durationMS;
+        private readonly Queue<DateTime> _hitList;
+    
+        public UnityRateLimiter(int hits, int duration_ms)
+        {
+          _hits = hits;
+          _durationMS = duration_ms;
+          _hitList = new Queue<DateTime>();
+        }
+    
+        public static UnityRateLimiter Create() => new UnityRateLimiter(1, 0);
+    
+        public bool CanFire()
+        {
+          DateTime utcNow = DateTime.UtcNow;
+          DateTime dateTime = NextFireAllowed(utcNow);
+          return utcNow >= dateTime;
+        }
+    
+        public async void Fire()
+        {
+          DateTime utcNow = DateTime.UtcNow;
+          DateTime dateTime = NextFireAllowed(utcNow);
+          await UniTask.Delay(dateTime.Subtract(utcNow));
+          if (_durationMS <= 0)
+            return;
+          _hitList.Enqueue(DateTime.UtcNow);
+        }
+    
+        private DateTime NextFireAllowed(DateTime checkTime)
+        {
+          DateTime dateTime1 = checkTime;
+          if (_durationMS == 0 || _hitList.Count == 0)
+            return dateTime1;
+          DateTime dateTime2 = checkTime.AddMilliseconds(-_durationMS);
+          while (_hitList.Count > 0 && _hitList.Peek().Subtract(dateTime2).TotalMilliseconds < 0.0)
+            _hitList.Dequeue();
+          return _hitList.Count >= _hits ? _hitList.Peek().AddMilliseconds(_durationMS) : checkTime;
+        }
+    
+        public UnityRateLimiter PerSeconds(int seconds)
+        {
+          _durationMS = seconds * 1000;
+          return this;
+        }
+    
+        public UnityRateLimiter PerMs(int ms)
+        {
+          _durationMS = ms;
+          return this;
+        }
+    
+        public UnityRateLimiter AllowHits(int hits)
+        {
+          _hits = hits;
+          return this;
+        }
+    
+        public override string ToString() => _hitList.Count > 0 ? string.Format("{0}-{1}", _hitList.Count, _hitList.Peek().ToString("HH:mm:ss.fff")) : "(empty)";
+      }
+}

--- a/Runtime/codebase/UnityRateLimiter.cs.meta
+++ b/Runtime/codebase/UnityRateLimiter.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 6fed2f2b621b449e82a4535da42b8602
+timeCreated: 1690040913

--- a/Runtime/codebase/WalletBase.cs
+++ b/Runtime/codebase/WalletBase.cs
@@ -28,6 +28,9 @@ namespace Solana.Unity.SDK
     {
         public const long SolLamports = 1000000000;
         public RpcCluster RpcCluster  { get; }
+        
+        public int RpcMaxHits = 20;
+        public int RpcMaxHitsPerSeconds = 1;
 
         private readonly Dictionary<int, Cluster> _rpcClusterMap = new ()
         {
@@ -320,11 +323,18 @@ namespace Solana.Unity.SDK
             {
                 if (_activeRpcClient == null && CustomRpcUri.IsNullOrEmpty())
                 {
-                    _activeRpcClient = ClientFactory.GetClient(_rpcClusterMap[(int)RpcCluster]);
+                    _activeRpcClient = ClientFactory.GetClient(
+                        _rpcClusterMap[(int)RpcCluster], 
+                        null, 
+                        rateLimiter: UnityRateLimiter.Create().AllowHits(RpcMaxHits).PerSeconds(RpcMaxHitsPerSeconds)
+                    );
                 }
                 if (_activeRpcClient == null && !CustomRpcUri.IsNullOrEmpty())
                 {
-                    _activeRpcClient = ClientFactory.GetClient(CustomRpcUri);
+                    _activeRpcClient = ClientFactory.GetClient(
+                        CustomRpcUri,
+                        null,
+                        rateLimiter: UnityRateLimiter.Create().AllowHits(2).PerSeconds(1));
                 }
 
                 return _activeRpcClient;

--- a/Runtime/codebase/WalletBase.cs
+++ b/Runtime/codebase/WalletBase.cs
@@ -29,7 +29,7 @@ namespace Solana.Unity.SDK
         public const long SolLamports = 1000000000;
         public RpcCluster RpcCluster  { get; }
         
-        public int RpcMaxHits = 20;
+        public int RpcMaxHits = 30;
         public int RpcMaxHitsPerSeconds = 1;
 
         private readonly Dictionary<int, Cluster> _rpcClusterMap = new ()
@@ -334,7 +334,7 @@ namespace Solana.Unity.SDK
                     _activeRpcClient = ClientFactory.GetClient(
                         CustomRpcUri,
                         null,
-                        rateLimiter: UnityRateLimiter.Create().AllowHits(2).PerSeconds(1));
+                        rateLimiter: UnityRateLimiter.Create().AllowHits(RpcMaxHits).PerSeconds(RpcMaxHitsPerSeconds));
                 }
 
                 return _activeRpcClient;

--- a/Runtime/codebase/Web3.cs
+++ b/Runtime/codebase/Web3.cs
@@ -54,7 +54,7 @@ namespace Solana.Unity.SDK
         private static WalletBase _wallet;
         private Web3AuthWallet _web3AuthWallet;
         
-        private int _defaultRpcMaxHits = 20;
+        private int _defaultRpcMaxHits = 30;
         public int RpcMaxHits
         {
 

--- a/Runtime/codebase/Web3.cs
+++ b/Runtime/codebase/Web3.cs
@@ -38,6 +38,8 @@ namespace Solana.Unity.SDK
                 _wallet = value;
                 if (currentWallet == null && value?.Account != null)
                 {
+                    value.RpcMaxHits = RpcMaxHits;
+                    value.RpcMaxHitsPerSeconds = RpcMaxHitsPerSeconds;
                     OnLogin?.Invoke(value.Account);
                     UpdateBalance().Forget();
                     if(OnNFTsUpdateInternal != null && AutoLoadNfts) UpdateNFTs().Forget();
@@ -52,6 +54,30 @@ namespace Solana.Unity.SDK
         private static WalletBase _wallet;
         private Web3AuthWallet _web3AuthWallet;
         
+        private int _defaultRpcMaxHits = 20;
+        public int RpcMaxHits
+        {
+
+            get => _wallet?.RpcMaxHits ?? _defaultRpcMaxHits;
+            set
+            {
+                if (_wallet != null) _wallet.RpcMaxHits = value;
+                else _defaultRpcMaxHits = value;
+            }
+        }
+        
+        private int _defaultRpcMaxHitsPerSeconds = 1;
+        public int RpcMaxHitsPerSeconds
+        {
+
+            get => _wallet?.RpcMaxHitsPerSeconds ?? _defaultRpcMaxHitsPerSeconds;
+            set
+            {
+                if (_wallet != null) _wallet.RpcMaxHitsPerSeconds = value;
+                else _defaultRpcMaxHitsPerSeconds = value;
+            }
+        }
+
         #endregion
 
         #region Wallet Options


### PR DESCRIPTION
# Add rate limiter

Implement a configurable Rate Limiter which can be used to support all 

| Status  | Type  | ⚠️ Core Change | Issue |
| :---: | :---: | :---: | :--: |
| Ready | Feature  | No |  |

## Problem

Free and low tier Rpc providers have a rate limit that could be hit easily

## Solution

Allow to rate limit requests