### PR TITLE
:bug: Handle rejection in WebGL wallet adapter

### DIFF
--- a/Runtime/Plugins/SolanaWalletAdapterWebGL/SolanaWalletAdapterWebGL.jslib
+++ b/Runtime/Plugins/SolanaWalletAdapterWebGL/SolanaWalletAdapterWebGL.jslib
@@ -24,6 +24,7 @@ mergeInto(LibraryManager.library, {
             Module.dynCall_vi(callback, walletsPtr);
         } catch (err) {
             console.error(err.message);
+            Module.dynCall_vi(callback, null);
         }
     },
     ExternConnectWallet: async function (walletNamePtr, callback) {
@@ -41,6 +42,7 @@ mergeInto(LibraryManager.library, {
                 Module.dynCall_vi(callback, pubKeyPtr);
          } catch (err) {
             console.error(err.message);
+            Module.dynCall_vi(callback, null);
          }
     },
     ExternSignTransactionWallet: async function (walletNamePtr, transactionPtr, callback) {
@@ -61,6 +63,7 @@ mergeInto(LibraryManager.library, {
                 Module.dynCall_vi(callback, txPtr);          
          } catch (err) {
             console.error(err.message);
+            Module.dynCall_vi(callback, null);
          }
     },
     ExternSignMessageWallet: async function (walletNamePtr, messagePtr, callback) {
@@ -82,6 +85,7 @@ mergeInto(LibraryManager.library, {
                 Module.dynCall_vi(callback, signaturePtr);          
          } catch (err) {
             console.error(err.message);
+            Module.dynCall_vi(callback, null);
          }
     },
      ExternSignAllTransactionsWallet: async function (walletNamePtr, transactionsPtr, callback) {
@@ -113,6 +117,7 @@ mergeInto(LibraryManager.library, {
                 Module.dynCall_vi(callback, txsPtr);
         } catch (err) {
             console.error(err.message);
+            Module.dynCall_vi(callback, null);
         }
     },
 } );

--- a/Runtime/codebase/SolanaWalletAdapterWebGL/SolanaWalletAdapterWebGL.cs
+++ b/Runtime/codebase/SolanaWalletAdapterWebGL/SolanaWalletAdapterWebGL.cs
@@ -5,7 +5,6 @@ using AOT;
 using Solana.Unity.Rpc.Models;
 using Solana.Unity.Wallet;
 using UnityEngine;
-using WebSocketSharp;
 
 // ReSharper disable once CheckNamespace
 
@@ -192,7 +191,7 @@ namespace Solana.Unity.SDK
         [MonoPInvokeCallback(typeof(Action<string>))]
         private static void OnWalletConnected(string walletPubKey)
         {
-            if (walletPubKey.IsNullOrEmpty())
+            if (walletPubKey == null)
             {
                 _loginTaskCompletionSource.TrySetException(new Exception("Login cancelled"));
                 _loginTaskCompletionSource.TrySetResult(null);
@@ -210,7 +209,7 @@ namespace Solana.Unity.SDK
         [MonoPInvokeCallback(typeof(Action<string>))]
         public static void OnTransactionSigned(string transaction)
         {
-            if (transaction.IsNullOrEmpty())
+            if (transaction == null)
             {
                 _signedTransactionTaskCompletionSource.TrySetException(new Exception("Transaction signing cancelled"));
                 _signedTransactionTaskCompletionSource.TrySetResult(null);
@@ -227,7 +226,7 @@ namespace Solana.Unity.SDK
         [MonoPInvokeCallback(typeof(Action<string>))]
         public static void OnAllTransactionsSigned(string signatures)
         {
-            if (signatures.IsNullOrEmpty())
+            if (signatures == null)
             {
                 _signedAllTransactionsTaskCompletionSource.TrySetException(new Exception("Transactions signing cancelled"));
                 _signedAllTransactionsTaskCompletionSource.TrySetResult(null);
@@ -253,7 +252,7 @@ namespace Solana.Unity.SDK
         [MonoPInvokeCallback(typeof(Action<string>))]
         public static void OnMessageSigned(string signature)
         {
-            if (signature.IsNullOrEmpty())
+            if (signature == null)
             {
                 _signedMessageTaskCompletionSource.TrySetException(new Exception("Message signing cancelled"));
                 _signedMessageTaskCompletionSource.TrySetResult(null);

--- a/Runtime/codebase/SolanaWalletAdapterWebGL/SolanaWalletAdapterWebGL.cs
+++ b/Runtime/codebase/SolanaWalletAdapterWebGL/SolanaWalletAdapterWebGL.cs
@@ -5,6 +5,7 @@ using AOT;
 using Solana.Unity.Rpc.Models;
 using Solana.Unity.Wallet;
 using UnityEngine;
+using WebSocketSharp;
 
 // ReSharper disable once CheckNamespace
 
@@ -191,9 +192,15 @@ namespace Solana.Unity.SDK
         [MonoPInvokeCallback(typeof(Action<string>))]
         private static void OnWalletConnected(string walletPubKey)
         {
+            if (walletPubKey.IsNullOrEmpty())
+            {
+                _loginTaskCompletionSource.TrySetException(new Exception("Login cancelled"));
+                _loginTaskCompletionSource.TrySetResult(null);
+                return;
+            }
             Debug.Log($"Wallet {walletPubKey} connected!");
             _account = new Account("", walletPubKey);
-            _loginTaskCompletionSource.SetResult(_account);
+            _loginTaskCompletionSource.TrySetResult(_account);
         }
 
         /// <summary>
@@ -203,6 +210,12 @@ namespace Solana.Unity.SDK
         [MonoPInvokeCallback(typeof(Action<string>))]
         public static void OnTransactionSigned(string transaction)
         {
+            if (transaction.IsNullOrEmpty())
+            {
+                _signedTransactionTaskCompletionSource.TrySetException(new Exception("Transaction signing cancelled"));
+                _signedTransactionTaskCompletionSource.TrySetResult(null);
+                return;
+            }
             var tx = Transaction.Deserialize(Convert.FromBase64String(transaction));
             _signedTransactionTaskCompletionSource.SetResult(tx);
         }
@@ -214,6 +227,12 @@ namespace Solana.Unity.SDK
         [MonoPInvokeCallback(typeof(Action<string>))]
         public static void OnAllTransactionsSigned(string signatures)
         {
+            if (signatures.IsNullOrEmpty())
+            {
+                _signedAllTransactionsTaskCompletionSource.TrySetException(new Exception("Transactions signing cancelled"));
+                _signedAllTransactionsTaskCompletionSource.TrySetResult(null);
+                return;
+            }
             string[] signaturesList = signatures.Split(',');
             for (int i = 0; i < signaturesList.Length; i++)
             {
@@ -234,6 +253,12 @@ namespace Solana.Unity.SDK
         [MonoPInvokeCallback(typeof(Action<string>))]
         public static void OnMessageSigned(string signature)
         {
+            if (signature.IsNullOrEmpty())
+            {
+                _signedMessageTaskCompletionSource.TrySetException(new Exception("Message signing cancelled"));
+                _signedMessageTaskCompletionSource.TrySetResult(null);
+                return;
+            }
             _signedMessageTaskCompletionSource.SetResult(Convert.FromBase64String(signature));
         }
 


### PR DESCRIPTION
# Handle rejection in WebGL wallet adapter

| Status  | Type  | ⚠️ Core Change | Issue |
| :---: | :---: | :---: | :--: |
| Ready | Feature/Bug | No | - |

## Problem

WebGL Wallet Adapter is not returning anything when the user reject to sign a message/transaction

## Solution

Handle rejection and propagate the exception 