### PR TITLE
:sparkles: Expose Web3Auth user info

### DIFF
--- a/Runtime/codebase/Web3AuthWallet.cs
+++ b/Runtime/codebase/Web3AuthWallet.cs
@@ -1,12 +1,9 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Text;
 using System.Threading.Tasks;
 using Merkator.Tools;
-using Newtonsoft.Json;
 using Solana.Unity.Wallet;
 using Solana.Unity.Rpc.Models;
-using Solana.Unity.Wallet.Utilities;
 using UnityEngine;
 
 // ReSharper disable once CheckNamespace

--- a/Runtime/codebase/Web3AuthWallet.cs
+++ b/Runtime/codebase/Web3AuthWallet.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Text;
 using System.Threading.Tasks;
 using Merkator.Tools;
+using Newtonsoft.Json;
 using Solana.Unity.Wallet;
 using Solana.Unity.Rpc.Models;
 using Solana.Unity.Wallet.Utilities;
@@ -36,6 +37,7 @@ namespace Solana.Unity.SDK
         private TaskCompletionSource<Web3AuthResponse> _taskCompletionSource;
         
         public event Action<Account> OnLoginNotify;
+        public UserInfo userInfo;
 
         public Web3AuthWallet(Web3AuthWalletOptions web3AuthWalletOptions,
             RpcCluster rpcCluster = RpcCluster.DevNet,
@@ -76,7 +78,6 @@ namespace Solana.Unity.SDK
         {
             var keyBytes = ArrayHelpers.SubArray(Convert.FromBase64String(response.ed25519PrivKey), 0, 64);
             var wallet = new Wallet.Wallet(keyBytes);
-            
             if (_loginTaskCompletionSource != null)
             {
                 _loginTaskCompletionSource?.SetResult(wallet.Account);
@@ -86,6 +87,7 @@ namespace Solana.Unity.SDK
                 Account = wallet.Account;
                 OnLoginNotify?.Invoke(wallet.Account);
             }
+            userInfo = response.userInfo;
         }
 
         protected override Task<Account> _Login(string password = null)


### PR DESCRIPTION
# Expose Web3Auth user info

| Status  | Type  | ⚠️ Core Change | Issue |
| :---: | :---: | :---: | :--: |
| Ready | Feature | No | - |

## Problem

Web3Auth UserInfo were not exposed after the login 

## Solution

Added a public userInfo field that can be accessed after the login:

As a simple example, a script can register to the OnLogin event and print the user email, if available.
```csharp
public void Start()
{
    Web3.OnLogin += OnLogin;
}

private void OnLogin(Account obj)
{
    if(Web3.Wallet is Web3AuthWallet) Debug.Log(((Web3AuthWallet)Web3.Wallet).userInfo?.email);
}
```