### PR TITLE
:sparkles: Keep connection active with Phantom deeplink wallet

### DIFF
--- a/Runtime/codebase/PhantomWallet.cs
+++ b/Runtime/codebase/PhantomWallet.cs
@@ -14,6 +14,7 @@ namespace Solana.Unity.SDK
         public string phantomApiVersion = "v1";
         public string appMetaDataUrl = "https://github.com/garbles-labs/Solana.Unity-SDK";
         public string deeplinkUrlScheme = "unitydl";
+        public string sessionEncryptionPassword = "use a strong password";
     }
     
     


### PR DESCRIPTION
# Keep connection active with Phantom deeplink wallet

| Status  | Type  | ⚠️ Core Change | Issue |
| :---: | :---: | :---: | :--: |
| Ready | Feature | No | - |

## Problem

Phantom Deeplink wallet implementation (used on iOS) was requiring to login at each app interaction.

## Solution

- Add a deterministic psw derivation to save the phantom session_id and the channel encryption keypair
- Save and load session information automatically on login  