### PR TITLE
Set rpc cluster name as global window variable for walletAdapterLib

### DIFF
--- a/Runtime/Plugins/SolanaWalletAdapterWebGL/SolanaWalletAdapterWebGL.jslib
+++ b/Runtime/Plugins/SolanaWalletAdapterWebGL/SolanaWalletAdapterWebGL.jslib
@@ -1,130 +1,163 @@
 mergeInto(LibraryManager.library, {
-    InitWalletAdapter: async function (callback) {
-        const isXnft = Boolean("xnft" in window && window.xnft != undefined && window.xnft.solana != undefined && window.xnft.solana.publicKey != undefined);
-        // Add UnityWalletAdapter from CDN
-        if(window.walletAdapterLib == undefined){
-            console.log("Adding WalletAdapterLib")
-            var script = document.createElement("script");
-            script.src = "https://cdn.jsdelivr.net/gh/magicblock-labs/unity-js-wallet-adapter@main/dist/wallet-adapter-lib.js";
-            document.head.appendChild(script);
-            script.onload = function() {
-                console.log("WalletAdapterLib loaded");
-                Module.dynCall_vi(callback, isXnft);
-            };
-        }else{
-            Module.dynCall_vi(callback, isXnft);
+  InitWalletAdapter: async function (callback, rpcClusterPtr) {
+    const isXnft = Boolean(
+      "xnft" in window &&
+        window.xnft != undefined &&
+        window.xnft.solana != undefined &&
+        window.xnft.solana.publicKey != undefined
+    );
+    window.rpcCluster = UTF8ToString(rpcClusterPtr);
+    // Add UnityWalletAdapter from CDN
+    if (window.walletAdapterLib == undefined) {
+      var script = document.createElement("script");
+      script.src =
+        "https://cdn.jsdelivr.net/gh/magicblock-labs/unity-js-wallet-adapter@main/dist/wallet-adapter-lib.js";
+      document.head.appendChild(script);
+      script.onload = function () {
+        Module.dynCall_vi(callback, isXnft);
+      };
+    } else {
+      Module.dynCall_vi(callback, isXnft);
+    }
+  },
+  ExternGetWallets: async function (callback) {
+    try {
+      const wallets = await window.walletAdapterLib.getWallets();
+      var bufferSize = lengthBytesUTF8(wallets) + 1;
+      var walletsPtr = _malloc(bufferSize);
+      stringToUTF8(wallets, walletsPtr, bufferSize);
+      Module.dynCall_vi(callback, walletsPtr);
+    } catch (err) {
+      console.error(err.message);
+      Module.dynCall_vi(callback, null);
+    }
+  },
+  ExternConnectWallet: async function (walletNamePtr, callback) {
+    try {
+      const walletName = UTF8ToString(walletNamePtr);
+      var pubKey;
+      if (walletName === "XNFT") {
+        pubKey = window.xnft.solana.publicKey.toString();
+      } else {
+        pubKey = await window.walletAdapterLib.connectWallet(walletName);
+      }
+      if (pubKey == undefined) {
+        throw new Error("Unable to connect to: " + walletName);
+      }
+      var bufferSize = lengthBytesUTF8(pubKey) + 1;
+      var pubKeyPtr = _malloc(bufferSize);
+      stringToUTF8(pubKey, pubKeyPtr, bufferSize);
+      Module.dynCall_vi(callback, pubKeyPtr);
+    } catch (err) {
+      console.error(err.message);
+      Module.dynCall_vi(callback, null);
+    }
+  },
+  ExternSignTransactionWallet: async function (
+    walletNamePtr,
+    transactionPtr,
+    callback
+  ) {
+    try {
+      const walletName = UTF8ToString(walletNamePtr);
+      var base64transaction = UTF8ToString(transactionPtr);
+      let signedTransaction;
+      if (walletName === "XNFT") {
+        const transaction =
+          window.walletAdapterLib.getTransactionFromStr(base64transaction);
+        signedTransaction = await window.xnft.solana.signTransaction(
+          transaction
+        );
+      } else {
+        signedTransaction = await window.walletAdapterLib.signTransaction(
+          walletName,
+          base64transaction
+        );
+      }
+      let txStr = Buffer.from(signedTransaction.serialize()).toString("base64");
+      var bufferSize = lengthBytesUTF8(txStr) + 1;
+      var txPtr = _malloc(bufferSize);
+      stringToUTF8(txStr, txPtr, bufferSize);
+      Module.dynCall_vi(callback, txPtr);
+    } catch (err) {
+      console.error(err.message);
+      Module.dynCall_vi(callback, null);
+    }
+  },
+  ExternSignMessageWallet: async function (
+    walletNamePtr,
+    messagePtr,
+    callback
+  ) {
+    try {
+      const walletName = UTF8ToString(walletNamePtr);
+      var base64Message = UTF8ToString(messagePtr);
+      let signatureStr;
+      if (walletName === "XNFT") {
+        const messageBytes = Uint8Array.from(atob(base64Message), (c) =>
+          c.charCodeAt(0)
+        );
+        const signedMessage = await window.xnft.solana.signMessage(
+          messageBytes
+        );
+        signatureStr = btoa(String.fromCharCode(...signedMessage));
+      } else {
+        var signature = await window.walletAdapterLib.signMessage(
+          walletName,
+          atob(base64Message)
+        );
+        signatureStr = signature.toString("base64");
+      }
+      var bufferSize = lengthBytesUTF8(signatureStr) + 1;
+      var signaturePtr = _malloc(bufferSize);
+      stringToUTF8(signatureStr, signaturePtr, bufferSize);
+      Module.dynCall_vi(callback, signaturePtr);
+    } catch (err) {
+      console.error(err.message);
+      Module.dynCall_vi(callback, null);
+    }
+  },
+  ExternSignAllTransactionsWallet: async function (
+    walletNamePtr,
+    transactionsPtr,
+    callback
+  ) {
+    try {
+      const walletName = UTF8ToString(walletNamePtr);
+      var base64transactionsStr = UTF8ToString(transactionsPtr);
+      var base64transactions = base64transactionsStr.split(",");
+      let signedTransactions;
+      if (walletName === "XNFT") {
+        let transactions = [];
+        for (var i = 0; i < base64transactions.length; i++) {
+          const transaction = window.walletAdapterLib.getTransactionFromStr(
+            base64transactions[i]
+          );
+          transactions.push(transaction);
         }
-    },
-     ExternGetWallets: async function(callback) {
-        try {
-            const wallets = await window.walletAdapterLib.getWallets();
-            var bufferSize = lengthBytesUTF8(wallets) + 1;
-            var walletsPtr = _malloc(bufferSize);
-            stringToUTF8(wallets, walletsPtr, bufferSize);
-            Module.dynCall_vi(callback, walletsPtr);
-        } catch (err) {
-            console.error(err.message);
-            Module.dynCall_vi(callback, null);
-        }
-    },
-    ExternConnectWallet: async function (walletNamePtr, callback) {
-         try {
-                const walletName = UTF8ToString(walletNamePtr)
-                var pubKey;
-                if(walletName === 'XNFT'){
-                    pubKey = window.xnft.solana.publicKey.toString();
-                } else {
-                    pubKey = await window.walletAdapterLib.connectWallet(walletName);
-                }
-                if(pubKey == undefined){
-                    throw new Error('Unable to connect to: ' + walletName);
-                }
-                var bufferSize = lengthBytesUTF8(pubKey) + 1;
-                var pubKeyPtr = _malloc(bufferSize);
-                stringToUTF8(pubKey, pubKeyPtr, bufferSize);
-                Module.dynCall_vi(callback, pubKeyPtr);
-         } catch (err) {
-            console.error(err.message);
-            Module.dynCall_vi(callback, null);
-         }
-    },
-    ExternSignTransactionWallet: async function (walletNamePtr, transactionPtr, callback) {
-         try {
-                const walletName = UTF8ToString(walletNamePtr)
-                var base64transaction = UTF8ToString(transactionPtr)
-                let signedTransaction;
-                if(walletName === 'XNFT'){
-                    const transaction = window.walletAdapterLib.getTransactionFromStr(base64transaction);
-                    signedTransaction = await window.xnft.solana.signTransaction(transaction);
-                } else {
-                    signedTransaction = await window.walletAdapterLib.signTransaction(walletName, base64transaction);
-                }
-                let txStr = Buffer.from(signedTransaction.serialize()).toString('base64');
-                var bufferSize = lengthBytesUTF8(txStr) + 1;
-                var txPtr = _malloc(bufferSize);
-                stringToUTF8(txStr, txPtr, bufferSize);
-                Module.dynCall_vi(callback, txPtr);     
-         } catch (err) {
-            console.error(err.message);
-            Module.dynCall_vi(callback, null);
-         } 
-    },
-    ExternSignMessageWallet: async function (walletNamePtr, messagePtr, callback) {
-         try {
-                const walletName = UTF8ToString(walletNamePtr)
-                var base64Message = UTF8ToString(messagePtr)
-                let signatureStr;
-                 if(walletName === 'XNFT'){  
-                  const messageBytes = Uint8Array.from(atob(base64Message), (c) => c.charCodeAt(0));
-                  const signedMessage = await window.xnft.solana.signMessage(messageBytes);
-                  signatureStr = btoa(String.fromCharCode(...signedMessage));
-                } else {
-                    var signature = await window.walletAdapterLib.signMessage(walletName, atob(base64Message));
-                    signatureStr =  signature.toString('base64');
-                }
-                var bufferSize = lengthBytesUTF8(signatureStr) + 1;
-                var signaturePtr = _malloc(bufferSize);
-                stringToUTF8(signatureStr, signaturePtr, bufferSize);
-                Module.dynCall_vi(callback, signaturePtr);          
-         } catch (err) {
-            console.error(err.message);
-            Module.dynCall_vi(callback, null);
-         }
-    },
-     ExternSignAllTransactionsWallet: async function (walletNamePtr, transactionsPtr, callback) {
-         try {
-                const walletName = UTF8ToString(walletNamePtr)
-                var base64transactionsStr = UTF8ToString(transactionsPtr)
-                var base64transactions = base64transactionsStr.split(',');
-                let signedTransactions;
-                if(walletName === 'XNFT'){
-                    let transactions = [];
-                    for(var i = 0; i < base64transactions.length; i++){
-                        const transaction = window.walletAdapterLib.getTransactionFromStr(base64transactions[i]);
-                        transactions.push(transaction);
-                    }
-                    signedTransactions = await window.xnft.solana.signAllTransactions(transactions);
-                } else {
-                    signedTransactions = await window.walletAdapterLib.signAllTransactions(walletName, base64transactions);
-                }
-                var serializedSignedTransactions = [];
-                for (var i = 0; i < signedTransactions.length; i++) {
-                    var signedTransaction = signedTransactions[i];
-                    var txStr = signedTransaction.serialize().toString('base64');
-                    serializedSignedTransactions.push(txStr);
-                }
-                var txsStr = serializedSignedTransactions.join(',');
-                var bufferSize = lengthBytesUTF8(txsStr) + 1;
-                var txsPtr = _malloc(bufferSize);
-                stringToUTF8(txsStr, txsPtr, bufferSize);
-                Module.dynCall_vi(callback, txsPtr);
-        } catch (err) {
-            console.error(err.message);
-            Module.dynCall_vi(callback, null);
-        }
-    },
-} );
-
-
-
- 
+        signedTransactions = await window.xnft.solana.signAllTransactions(
+          transactions
+        );
+      } else {
+        signedTransactions = await window.walletAdapterLib.signAllTransactions(
+          walletName,
+          base64transactions
+        );
+      }
+      var serializedSignedTransactions = [];
+      for (var i = 0; i < signedTransactions.length; i++) {
+        var signedTransaction = signedTransactions[i];
+        var txStr = signedTransaction.serialize().toString("base64");
+        serializedSignedTransactions.push(txStr);
+      }
+      var txsStr = serializedSignedTransactions.join(",");
+      var bufferSize = lengthBytesUTF8(txsStr) + 1;
+      var txsPtr = _malloc(bufferSize);
+      stringToUTF8(txsStr, txsPtr, bufferSize);
+      Module.dynCall_vi(callback, txsPtr);
+    } catch (err) {
+      console.error(err.message);
+      Module.dynCall_vi(callback, null);
+    }
+  },
+});

--- a/Runtime/Plugins/SolanaWalletAdapterWebGL/SolanaWalletAdapterWebGL.jslib
+++ b/Runtime/Plugins/SolanaWalletAdapterWebGL/SolanaWalletAdapterWebGL.jslib
@@ -11,12 +11,13 @@ mergeInto(LibraryManager.library, {
     if (window.walletAdapterLib == undefined) {
       var script = document.createElement("script");
       script.src =
-        "https://cdn.jsdelivr.net/gh/magicblock-labs/unity-js-wallet-adapter@main/dist/wallet-adapter-lib.js";
+        "https://cdn.jsdelivr.net/gh/magicblock-labs/unity-js-wallet-adapter@v1.2.0/dist/wallet-adapter-lib.js";
       document.head.appendChild(script);
       script.onload = function () {
         Module.dynCall_vi(callback, isXnft);
       };
     } else {
+      window.walletAdapterLib.refreshWalletAdapters();
       Module.dynCall_vi(callback, isXnft);
     }
   },

--- a/Runtime/codebase/SolanaWalletAdapterWebGL/SolanaWalletAdapterWebGL.cs
+++ b/Runtime/codebase/SolanaWalletAdapterWebGL/SolanaWalletAdapterWebGL.cs
@@ -52,6 +52,8 @@ namespace Solana.Unity.SDK
         public static WalletSpecs[] Wallets { get; private set; }
 
         private static WalletSpecs _currentWallet;
+
+        private static string _clusterName;
             
 
         [Obsolete("Use SolanaWalletAdapter class instead, which is the cross platform wrapper.")]
@@ -68,12 +70,14 @@ namespace Solana.Unity.SDK
             {
                 throw new Exception("SolanaWalletAdapterWebGL can only be used on WebGL");
             }
+            _clusterName = RPCNameMap[(int)RpcCluster];
         }
         
         private static async Task InitWallets() {
             _currentWallet = null;
             _walletsInitializedTaskCompletionSource = new TaskCompletionSource<bool>();
-            InitWalletAdapter(OnWalletsInitialized);
+            
+            InitWalletAdapter(OnWalletsInitialized, _clusterName);
             bool isXnft = await _walletsInitializedTaskCompletionSource.Task;
             if (isXnft){
                _currentWallet = new WalletSpecs()
@@ -300,7 +304,7 @@ namespace Solana.Unity.SDK
                 private static extern string  ExternGetWallets(Action<string> callback);
 
                 [DllImport("__Internal")]
-                private static extern void InitWalletAdapter(Action<bool> callback);
+                private static extern void InitWalletAdapter(Action<bool> callback, string clusterName);
                 
                 
         #else
@@ -309,7 +313,7 @@ namespace Solana.Unity.SDK
                 private static void ExternSignAllTransactionsWallet(string walletName, string transactions, Action<string> callback){}
                 private static void ExternSignMessageWallet(string walletName, string messageBase64, Action<string> callback){}
                 private static string ExternGetWallets(Action<string> callback){return null;}
-                private static void InitWalletAdapter(Action<bool> callback){}
+                private static void InitWalletAdapter(Action<bool> callback, string clusterName){}
                 
         #endif
     }


### PR DESCRIPTION
| Status  | Type  | ⚠️ Core Change | Issue |
| :---: | :---: | :---: | :--: |
| Ready| Feature | No | #200  |

## Problem

Include Solana Mobile Wallet Adapter for WebGL builds when running in mobile.

## Solution

Most of the code containing the solution is in the [unity-js-wallet-adapter](https://github.com/magicblock-labs/unity-js-wallet-adapter) where SolanaMobileWallet adapter instance is created when running in mobile. For that, we needed to pass the RPC cluser selected to the JS runtime. We just do that here, by setting a global variable  window.rpcCluster with the cluster name from Unity thorugh jslib.


## Deploy Notes

It's important to note that this PR alone does not provide the solution, it has a strict dependency on the [PR for unity-js-wallet-adapter]( https://github.com/magicblock-labs/unity-js-wallet-adapter/pull/6)
