### PR TITLE
:sparkles: Update Web3Auth SDK to v2.1.1

### DIFF
--- a/Runtime/Plugins/Web3AuthSDK/Types/AES256CBC.cs
+++ b/Runtime/Plugins/Web3AuthSDK/Types/AES256CBC.cs
@@ -135,7 +135,7 @@ public class AES256CBC
     public bool hmacSha256Verify(byte[] key, byte[] data, string sig)
     {
         byte[] expectedSig = hmacSha256Sign(key, data);
-        string expectedSigHex = BitConverter.ToString(expectedSig).Replace("-", "").ToLower();
+        string expectedSigHex = BitConverter.ToString(expectedSig).Replace("-", "").ToLowerInvariant();
         return expectedSigHex.Equals(sig);
     }
 }

--- a/Runtime/Plugins/Web3AuthSDK/Types/LoginParams.cs
+++ b/Runtime/Plugins/Web3AuthSDK/Types/LoginParams.cs
@@ -18,5 +18,5 @@ public class LoginParams
     [Preserve]
     public MFALevel mfaLevel { get; set; }
     [Preserve]
-    public Curve curve { get; set; }
+    public Curve curve { get; set; } = Curve.SECP256K1;
 }

--- a/Runtime/Plugins/Web3AuthSDK/Types/Web3AuthOptions.cs
+++ b/Runtime/Plugins/Web3AuthSDK/Types/Web3AuthOptions.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 #nullable enable
 #pragma warning disable CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.
@@ -20,7 +20,7 @@ public class Web3AuthOptions {
         }
         set { }
     }
-    public const string openLoginVersion = "v5";
+    public const string openLoginVersion = "v6";
 
     public WhiteLabelData? whiteLabel { get; set; }
     public Dictionary<string, LoginConfigItem>? loginConfig { get; set; }

--- a/Runtime/Plugins/Web3AuthSDK/Types/Web3AuthResponse.cs
+++ b/Runtime/Plugins/Web3AuthSDK/Types/Web3AuthResponse.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using UnityEngine.Scripting;
 
 [Serializable]

--- a/Runtime/Plugins/Web3AuthSDK/Web3Auth.cs
+++ b/Runtime/Plugins/Web3AuthSDK/Web3Auth.cs
@@ -1,4 +1,4 @@
-﻿using Newtonsoft.Json;
+using Newtonsoft.Json;
 using Newtonsoft.Json.Converters;
 using System;
 using System.Collections.Generic;
@@ -62,7 +62,7 @@ public class Web3Auth : MonoBehaviour
         this.initParams = new Dictionary<string, object>();
 
         this.initParams["clientId"] = clientId;
-        this.initParams["network"] = network.ToString().ToLower();
+        this.initParams["network"] = network.ToString().ToLowerInvariant();
 
         if (!string.IsNullOrEmpty(redirectUri))
             this.initParams["redirectUrl"] = redirectUri;
@@ -108,12 +108,13 @@ public class Web3Auth : MonoBehaviour
         if (this.web3AuthOptions.loginConfig != null)
             this.initParams["loginConfig"] = JsonConvert.SerializeObject(this.web3AuthOptions.loginConfig, settings);
 
-        if (!string.IsNullOrEmpty(this.web3AuthOptions.clientId))
+        if (this.web3AuthOptions.clientId != null)
             this.initParams["clientId"] = this.web3AuthOptions.clientId;
 
-        this.initParams["buildEnv"] = this.web3AuthOptions.buildEnv.ToString().ToLower();
+        if (this.web3AuthOptions.buildEnv != null)
+            this.initParams["buildEnv"] = this.web3AuthOptions.buildEnv.ToString().ToLowerInvariant();
 
-        this.initParams["network"] = this.web3AuthOptions.network.ToString().ToLower();
+        this.initParams["network"] = this.web3AuthOptions.network.ToString().ToLowerInvariant();
 
         if (this.web3AuthOptions.useCoreKitKey.HasValue)
             this.initParams["useCoreKitKey"] = this.web3AuthOptions.useCoreKitKey.Value;
@@ -124,7 +125,8 @@ public class Web3Auth : MonoBehaviour
         if (this.web3AuthOptions.mfaSettings != null)
             this.initParams["mfaSettings"] = JsonConvert.SerializeObject(this.web3AuthOptions.mfaSettings, settings);
 
-        this.initParams["sessionTime"] = this.web3AuthOptions.sessionTime;
+        if (this.web3AuthOptions.sessionTime != null)
+            this.initParams["sessionTime"] = this.web3AuthOptions.sessionTime;
     }
 
     private void onDeepLinkActivated(string url)


### PR DESCRIPTION
# Update Web3auth SDK to v2.1.1

| Status  | Type  | ⚠️ Core Change | Issue |
| :---: | :---: | :---: | :--: |
| Ready | Feature | No | - |

## Upgrade Web3auth SDK

Update Web3auth SDK to v2.1.1: https://github.com/Web3Auth/web3auth-unity-sdk/releases/tag/2.1.1