### PR TITLE
Update deprecated code inside jslib plugins

### DIFF
--- a/Runtime/Plugins/NativeWebSocket/NativeWebSocket.jslib
+++ b/Runtime/Plugins/NativeWebSocket/NativeWebSocket.jslib
@@ -149,8 +149,9 @@ var LibraryWebSocket = {
 			if (webSocketState.debug)
 				console.log("[JSLIB WebSocket] Connected.");
 
-			if (webSocketState.onOpen)
-				Module.dynCall_vi(webSocketState.onOpen, instanceId);
+			if (webSocketState.onOpen) {
+				{{{ makeDynCall('vi', 'webSocketState.onOpen') }}}(instanceId);
+			}
 
 		};
 
@@ -170,7 +171,7 @@ var LibraryWebSocket = {
 				HEAPU8.set(dataBuffer, buffer);
 
 				try {
-					Module.dynCall_viii(webSocketState.onMessage, instanceId, buffer, dataBuffer.length);
+					{{{ makeDynCall('viii', 'webSocketState.onMessage') }}}(instanceId, buffer, dataBuffer.length);
 				} finally {
 					_free(buffer);
 				}
@@ -182,7 +183,7 @@ var LibraryWebSocket = {
 				HEAPU8.set(dataBuffer, buffer);
 
 				try {
-					Module.dynCall_viii(webSocketState.onMessage, instanceId, buffer, dataBuffer.length);
+					{{{ makeDynCall('viii', 'webSocketState.onMessage') }}}(instanceId, buffer, dataBuffer.length);
 				} finally {
 					_free(buffer);
 				}
@@ -204,7 +205,7 @@ var LibraryWebSocket = {
 				stringToUTF8(msg, buffer, length);
 
 				try {
-					Module.dynCall_vii(webSocketState.onError, instanceId, buffer);
+					{{{ makeDynCall('vii', 'webSocketState.onError') }}}(instanceId, buffer);
 				} finally {
 					_free(buffer);
 				}
@@ -218,8 +219,9 @@ var LibraryWebSocket = {
 			if (webSocketState.debug)
 				console.log("[JSLIB WebSocket] Closed.");
 
-			if (webSocketState.onClose)
-				Module.dynCall_vii(webSocketState.onClose, instanceId, ev.code);
+			if (webSocketState.onClose) {
+				{{{ makeDynCall('vii', 'webSocketState.onClose') }}}(instanceId, ev.code);
+			}
 
 			delete instance.ws;
 

--- a/Runtime/Plugins/SolanaWalletAdapterWebGL/SolanaWalletAdapterWebGL.jslib
+++ b/Runtime/Plugins/SolanaWalletAdapterWebGL/SolanaWalletAdapterWebGL.jslib
@@ -14,11 +14,11 @@ mergeInto(LibraryManager.library, {
         "https://cdn.jsdelivr.net/npm/@magicblock-labs/unity-wallet-adapter@1.2.1";
       document.head.appendChild(script);
       script.onload = function () {
-        Module.dynCall_vi(callback, isXnft);
+        {{{ makeDynCall('vi', 'callback') }}}(isXnft);
       };
     } else {
       window.walletAdapterLib.refreshWalletAdapters();
-      Module.dynCall_vi(callback, isXnft);
+      {{{ makeDynCall('vi', 'callback') }}}(isXnft);
     }
   },
   ExternGetWallets: async function (callback) {
@@ -27,10 +27,10 @@ mergeInto(LibraryManager.library, {
       var bufferSize = lengthBytesUTF8(wallets) + 1;
       var walletsPtr = _malloc(bufferSize);
       stringToUTF8(wallets, walletsPtr, bufferSize);
-      Module.dynCall_vi(callback, walletsPtr);
+      {{{ makeDynCall('vi', 'callback') }}}(walletsPtr);
     } catch (err) {
       console.error(err.message);
-      Module.dynCall_vi(callback, null);
+      {{{ makeDynCall('vi', 'callback') }}}(null);
     }
   },
   ExternConnectWallet: async function (walletNamePtr, callback) {
@@ -48,10 +48,10 @@ mergeInto(LibraryManager.library, {
       var bufferSize = lengthBytesUTF8(pubKey) + 1;
       var pubKeyPtr = _malloc(bufferSize);
       stringToUTF8(pubKey, pubKeyPtr, bufferSize);
-      Module.dynCall_vi(callback, pubKeyPtr);
+      {{{ makeDynCall('vi', 'callback') }}}(pubKeyPtr);
     } catch (err) {
       console.error(err.message);
-      Module.dynCall_vi(callback, null);
+      {{{ makeDynCall('vi', 'callback') }}}(null);
     }
   },
   ExternSignTransactionWallet: async function (
@@ -79,10 +79,10 @@ mergeInto(LibraryManager.library, {
       var bufferSize = lengthBytesUTF8(txStr) + 1;
       var txPtr = _malloc(bufferSize);
       stringToUTF8(txStr, txPtr, bufferSize);
-      Module.dynCall_vi(callback, txPtr);
+      {{{ makeDynCall('vi', 'callback') }}}(txPtr);
     } catch (err) {
       console.error(err.message);
-      Module.dynCall_vi(callback, null);
+      {{{ makeDynCall('vi', 'callback') }}}(null);
     }
   },
   ExternSignMessageWallet: async function (
@@ -119,10 +119,10 @@ mergeInto(LibraryManager.library, {
       var bufferSize = lengthBytesUTF8(signatureStr) + 1;
       var signaturePtr = _malloc(bufferSize);
       stringToUTF8(signatureStr, signaturePtr, bufferSize);
-      Module.dynCall_vi(callback, signaturePtr);
+      {{{ makeDynCall('vi', 'callback') }}}(signaturePtr);
     } catch (err) {
       console.error(err.message);
-      Module.dynCall_vi(callback, null);
+      {{{ makeDynCall('vi', 'callback') }}}(null);
     }
   },
   ExternSignAllTransactionsWallet: async function (
@@ -162,10 +162,10 @@ mergeInto(LibraryManager.library, {
       var bufferSize = lengthBytesUTF8(txsStr) + 1;
       var txsPtr = _malloc(bufferSize);
       stringToUTF8(txsStr, txsPtr, bufferSize);
-      Module.dynCall_vi(callback, txsPtr);
+      {{{ makeDynCall('vi', 'callback') }}}(txsPtr);
     } catch (err) {
       console.error(err.message);
-      Module.dynCall_vi(callback, null);
+      {{{ makeDynCall('vi', 'callback') }}}(null);
     }
   },
 });

--- a/Runtime/Plugins/WebGLSupport/WebGLInput/WebGLInput.jslib
+++ b/Runtime/Plugins/WebGLSupport/WebGLInput/WebGLInput.jslib
@@ -1,9 +1,7 @@
 var WebGLInput = {
     $instances: [],
 	WebGLInputInit : function() {
-		// Remove the `Runtime` object from "v1.37.27: 12/24/2017"
-		// if Runtime not defined. create and add functon!!
-		if(typeof Runtime === "undefined") Runtime = { dynCall : dynCall }
+		// Initialization if needed
 	},
     WebGLInputCreate: function (canvasId, x, y, width, height, fontsize, text, placeholder, isMultiLine, isPassword, isHidden, isMobile) {
         var container = document.getElementById(UTF8ToString(canvasId));
@@ -100,7 +98,7 @@ var WebGLInput = {
                     input.setSelectionRange(start + 1, start + 1);
                     input.oninput();	// call oninput to exe ValueChange function!!
 				} else {
-				    Runtime.dynCall("vii", cb, [id, e.shiftKey ? -1 : 1]);
+					{{{ makeDynCall('vii', 'cb') }}}(id, e.shiftKey ? -1 : 1);
 				}
             }
 		});
@@ -112,13 +110,13 @@ var WebGLInput = {
     WebGLInputOnFocus: function (id, cb) {
         var input = instances[id];
         input.onfocus = function () {
-            Runtime.dynCall("vi", cb, [id]);
+			{{{ makeDynCall('vi', 'cb') }}}(id);
         };
     },
     WebGLInputOnBlur: function (id, cb) {
         var input = instances[id];
         input.onblur = function () {
-            Runtime.dynCall("vi", cb, [id]);
+			{{{ makeDynCall('vi', 'cb') }}}(id);
         };
     },
 	WebGLInputIsFocus: function (id) {
@@ -127,17 +125,19 @@ var WebGLInput = {
 	WebGLInputOnValueChange:function(id, cb){
         var input = instances[id];
         input.oninput = function () {
-			var intArray = intArrayFromString(input.value);
-            var value = (allocate.length <= 2) ? allocate(intArray, ALLOC_NORMAL):allocate(intArray, 'i8', ALLOC_NORMAL);
-            Runtime.dynCall("vii", cb, [id,value]);
+			var lengthBytes = lengthBytesUTF8(input.value) + 1;
+            var stringOnHeap = _malloc(lengthBytes);
+            stringToUTF8(input.value, stringOnHeap, lengthBytes);
+			{{{ makeDynCall('vii', 'cb') }}}(id, stringOnHeap);
         };
     },
 	WebGLInputOnEditEnd:function(id, cb){
         var input = instances[id];
         input.onchange = function () {
-			var intArray = intArrayFromString(input.value);
-            var value = (allocate.length <= 2) ? allocate(intArray, ALLOC_NORMAL):allocate(intArray, 'i8', ALLOC_NORMAL);
-            Runtime.dynCall("vii", cb, [id,value]);
+			var lengthBytes = lengthBytesUTF8(input.value) + 1;
+            var stringOnHeap = _malloc(lengthBytes);
+            stringToUTF8(input.value, stringOnHeap, lengthBytes);
+			{{{ makeDynCall('vii', 'cb') }}}(id, stringOnHeap);
         };
     },
 	WebGLInputSelectionStart:function(id){

--- a/Runtime/Plugins/WebGLSupport/WebGLWindow/WebGLWindow.jslib
+++ b/Runtime/Plugins/WebGLSupport/WebGLWindow/WebGLWindow.jslib
@@ -1,22 +1,20 @@
 var WebGLWindow = {
 	WebGLWindowInit : function() {
-		// Remove the `Runtime` object from "v1.37.27: 12/24/2017"
-		// if Runtime not defined. create and add functon!!
-		if(typeof Runtime === "undefined") Runtime = { dynCall : dynCall }
+		// Initialization if needed
 	},
     WebGLWindowOnFocus: function (cb) {
         window.addEventListener('focus', function () {
-            Runtime.dynCall("v", cb, []);
+            {{{ makeDynCall('v', 'cb') }}}();
         });
     },
     WebGLWindowOnBlur: function (cb) {
         window.addEventListener('blur', function () {
-            Runtime.dynCall("v", cb, []);
+            {{{ makeDynCall('v', 'cb') }}}();
         });
     },
 	WebGLWindowOnResize: function(cb) {
         window.addEventListener('resize', function () {
-            Runtime.dynCall("v", cb, []);
+            {{{ makeDynCall('v', 'cb') }}}();
         });
 	},
 	WebGLWindowInjectFullscreen : function () {

--- a/Runtime/codebase/SolanaWalletAdapterWebGL/SolanaWalletAdapterWebGL.cs
+++ b/Runtime/codebase/SolanaWalletAdapterWebGL/SolanaWalletAdapterWebGL.cs
@@ -26,7 +26,6 @@ namespace Solana.Unity.SDK
         private static TaskCompletionSource<Transaction> _signedTransactionTaskCompletionSource;
         private static TaskCompletionSource<Transaction[]> _signedAllTransactionsTaskCompletionSource;
         private static TaskCompletionSource<byte[]> _signedMessageTaskCompletionSource;
-        private static Transaction[] _currentTransactions;
         private static Account _account;
         public static GameObject WalletAdapterUI { get; private set; }
 
@@ -176,7 +175,6 @@ namespace Solana.Unity.SDK
         protected override Task<Transaction[]> _SignAllTransactions(Transaction[] transactions)
         {
             _signedAllTransactionsTaskCompletionSource = new TaskCompletionSource<Transaction[]>();
-            _currentTransactions = transactions;
             string[] base64Transactions = new string[transactions.Length];
             for (int i = 0; i < transactions.Length; i++)
             {
@@ -237,15 +235,13 @@ namespace Solana.Unity.SDK
                 return;
             }
             string[] signaturesList = signatures.Split(',');
+            var transactions = new Transaction[signaturesList.Length];
+            
             for (int i = 0; i < signaturesList.Length; i++)
             {
-                _currentTransactions[i].Signatures.Add(new SignaturePubKeyPair()
-                {
-                    PublicKey = _account.PublicKey,
-                    Signature = Convert.FromBase64String(signaturesList[i])
-                });
+                transactions[i] = Transaction.Deserialize(signaturesList[i]);
             }
-            _signedAllTransactionsTaskCompletionSource.SetResult(_currentTransactions);
+            _signedAllTransactionsTaskCompletionSource.SetResult(transactions);
         }
         
         

--- a/Runtime/codebase/SolanaWalletAdapterWebGL/SolanaWalletAdapterWebGL.cs
+++ b/Runtime/codebase/SolanaWalletAdapterWebGL/SolanaWalletAdapterWebGL.cs
@@ -222,26 +222,26 @@ namespace Solana.Unity.SDK
         }
         
         /// <summary>
-        /// Called from javascript when the wallet signed all transactions and return the signature
-        /// that we then need to put into the transaction before we send it out.
+        /// Called from javascript when the wallet signs all transactions and returns the signed transactions,
+        /// which we then need to send out.
         /// </summary>
         [MonoPInvokeCallback(typeof(Action<string>))]
-        public static void OnAllTransactionsSigned(string signatures)
+        public static void OnAllTransactionsSigned(string transactions)
         {
-            if (signatures == null)
+            if (transactions == null)
             {
                 _signedAllTransactionsTaskCompletionSource.TrySetException(new Exception("Transactions signing cancelled"));
                 _signedAllTransactionsTaskCompletionSource.TrySetResult(null);
                 return;
             }
-            string[] signaturesList = signatures.Split(',');
-            var transactions = new Transaction[signaturesList.Length];
+            string[] transactionsList = transactions.Split(',');
+            var txList = new Transaction[transactionsList.Length];
             
-            for (int i = 0; i < signaturesList.Length; i++)
+            for (int i = 0; i < transactionsList.Length; i++)
             {
-                transactions[i] = Transaction.Deserialize(signaturesList[i]);
+                txList[i] = Transaction.Deserialize(transactionsList[i]);
             }
-            _signedAllTransactionsTaskCompletionSource.SetResult(transactions);
+            _signedAllTransactionsTaskCompletionSource.SetResult(txList);
         }
         
         


### PR DESCRIPTION
| Status  | Type  | ⚠️ Core Change | Issue |
| :---: | :---: | :---: | :--: |
| Ready|Hotfix | No | [Link](https://github.com/magicblock-labs/Solana.Unity-SDK/issues/233) |

## Problem

In the WebGL build of Unity 2023 and above, when enabling the "Target WebAssembly 2023" option in Player Settings > Publishing Settings, the game freezes after the initial loading.


## Solution

According to the Unity documentation at the link below:
https://docs.unity3d.com/6000.0/Documentation/Manual/web-interacting-browser-deprecated.html#dyncall
the dynCall() function has been deprecated and should be replaced with makeDynCall().
Please note that this change is backward-compatible, and there will be no issues even if the "Target WebAssembly 2023" option is not enabled.

As a result, I replaced this deprecated function with the new version in all the existing jslib plugins in your SDK, and ultimately, the issue with my build in Unity 6 was resolved when "Target WebAssembly 2023" was enabled.


## Other changes (e.g. bug fixes, small refactors)

Also, the allocate function was used in the WebGLInput plugin, which has also been deprecated, and I replaced it with its new equivalent.
