### PR TITLE
Hide LoginXNFT behind autoConnectOnStartup

### DIFF
--- a/Runtime/codebase/Web3.cs
+++ b/Runtime/codebase/Web3.cs
@@ -193,7 +193,9 @@ namespace Solana.Unity.SDK
             }
             
             #if UNITY_WEBGL
-            LoginXNFT().AsUniTask().Forget();
+            if (autoConnectOnStartup) {
+                LoginXNFT().AsUniTask().Forget();
+            }
             #endif
 
             


### PR DESCRIPTION

| Status  | Type  | ⚠️ Core Change | Issue |
| :---: | :---: | :---: | :--: |
| Ready|Hotfix |No | [Link](<Issue link here>) |

## Problem

_What problem are you trying to solve?_

There was no way to disable auto login when backpack wallet is installed. 

## Solution

_How did you solve the problem?_

Hide it behind the autoConnect flag

