### PR TITLE
improvement: Added customClient option in SignAndSendTransaction & Added detection of denial of transaction

### DIFF
--- a/Runtime/codebase/DeepLinkWallets/PhantomDeepLink.cs
+++ b/Runtime/codebase/DeepLinkWallets/PhantomDeepLink.cs
@@ -280,8 +280,10 @@ namespace Solana.Unity.SDK
                 result.TryGetValue("errorCode", out var errorCode);
                 _signedAllTransactionsTaskCompletionSource?.TrySetResult(null);
                 Debug.LogError($"Deeplink error: Error: {errorMessage} + Data: {data}");
+                SolanaWalletAdapter.TriggerUserApprovedTransaction(false);
                 return;
             }
+            else SolanaWalletAdapter.TriggerUserApprovedTransaction(true);
 
             data = data.Replace("#", "");
             var k = MontgomeryCurve25519.KeyExchange(_phantomEncryptionPubKey, PhantomConnectionAccountPrivateKey);
@@ -302,9 +304,11 @@ namespace Solana.Unity.SDK
             result.TryGetValue("errorMessage", out var errorMessage);
             if (!string.IsNullOrEmpty(errorMessage) || string.IsNullOrEmpty(data))
             {
+                SolanaWalletAdapter.TriggerUserApprovedTransaction(false);
                 Debug.LogError($"Deeplink error: Error: {errorMessage} + Data: {data}");
                 return;
             }
+            else SolanaWalletAdapter.TriggerUserApprovedTransaction(true);
             data = data.Replace("#", "");
             var k = MontgomeryCurve25519.KeyExchange(_phantomEncryptionPubKey, PhantomConnectionAccountPrivateKey);
             var unencryptedMessage = XSalsa20Poly1305.TryDecrypt(Encoders.Base58.DecodeData(data), k, Encoders.Base58.DecodeData(nonce));
@@ -323,9 +327,11 @@ namespace Solana.Unity.SDK
             result.TryGetValue("errorMessage", out var errorMessage);
             if (!string.IsNullOrEmpty(errorMessage) || string.IsNullOrEmpty(data))
             {
+                SolanaWalletAdapter.TriggerUserApprovedTransaction(false);
                 Debug.LogError($"Deeplink error: Error: {errorMessage} + Data: {data}");
                 return;
             }
+            else SolanaWalletAdapter.TriggerUserApprovedTransaction(true);
             data = data.Replace("#", "");
             var k = MontgomeryCurve25519.KeyExchange(_phantomEncryptionPubKey, PhantomConnectionAccountPrivateKey);
             var unencryptedMessage = XSalsa20Poly1305.TryDecrypt(Encoders.Base58.DecodeData(data), k, Encoders.Base58.DecodeData(nonce));

--- a/Runtime/codebase/SolanaMobileStack/SolanaMobileWalletAdapter.cs
+++ b/Runtime/codebase/SolanaMobileStack/SolanaMobileWalletAdapter.cs
@@ -11,7 +11,7 @@ using WebSocketSharp;
 
 namespace Solana.Unity.SDK
 {
-    
+
     [Serializable]
     public class SolanaMobileWalletAdapterOptions
     {
@@ -20,13 +20,13 @@ namespace Solana.Unity.SDK
         public string name = "Solana.Unity-SDK";
         public bool keepConnectionAlive = true;
     }
-    
-    
+
+
     [Obsolete("Use SolanaWalletAdapter class instead, which is the cross platform wrapper.")]
     public class SolanaMobileWalletAdapter : WalletBase
     {
         private readonly SolanaMobileWalletAdapterOptions _walletOptions;
-        
+
         private Transaction _currentTransaction;
 
         private TaskCompletionSource<Account> _loginTaskCompletionSource;
@@ -36,9 +36,9 @@ namespace Solana.Unity.SDK
 
         public SolanaMobileWalletAdapter(
             SolanaMobileWalletAdapterOptions solanaWalletOptions,
-            RpcCluster rpcCluster = RpcCluster.DevNet, 
-            string customRpcUri = null, 
-            string customStreamingRpcUri = null, 
+            RpcCluster rpcCluster = RpcCluster.DevNet,
+            string customRpcUri = null,
+            string customStreamingRpcUri = null,
             bool autoConnectOnStartup = false) : base(rpcCluster, customRpcUri, customStreamingRpcUri, autoConnectOnStartup
         )
         {
@@ -116,7 +116,7 @@ namespace Solana.Unity.SDK
                             authorization = await client.Reauthorize(
                                 new Uri(_walletOptions.identityUri),
                                 new Uri(_walletOptions.iconUri, UriKind.Relative),
-                                _walletOptions.name, _authToken);   
+                                _walletOptions.name, _authToken);
                         }
                     },
                     async client =>
@@ -125,6 +125,8 @@ namespace Solana.Unity.SDK
                     }
                 }
             );
+
+            SolanaWalletAdapter.TriggerUserApprovedTransaction(result.WasSuccessful);
             if (!result.WasSuccessful)
             {
                 Debug.LogError(result.Error.Message);
@@ -165,7 +167,7 @@ namespace Solana.Unity.SDK
                             authorization = await client.Reauthorize(
                                 new Uri(_walletOptions.identityUri),
                                 new Uri(_walletOptions.iconUri, UriKind.Relative),
-                                _walletOptions.name, _authToken);   
+                                _walletOptions.name, _authToken);
                         }
                     },
                     async client =>

--- a/Runtime/codebase/SolanaWalletAdapter.cs
+++ b/Runtime/codebase/SolanaWalletAdapter.cs
@@ -15,10 +15,17 @@ namespace Solana.Unity.SDK
         public SolanaWalletAdapterWebGLOptions solanaWalletAdapterWebGLOptions;
         public PhantomWalletOptions phantomWalletOptions;
     }
-    
+
     public class SolanaWalletAdapter: WalletBase
     {
         private readonly WalletBase _internalWallet;
+
+        public static event EventHandler<bool> UserApprovedTransaction;
+
+        internal static void TriggerUserApprovedTransaction(bool approvedTransaction)
+        {
+            UserApprovedTransaction?.Invoke(null, approvedTransaction);
+        }
 
         public SolanaWalletAdapter(SolanaWalletAdapterOptions options, RpcCluster rpcCluster = RpcCluster.DevNet, string customRpcUri = null, string customStreamingRpcUri = null, bool autoConnectOnStartup = false) : base(rpcCluster, customRpcUri, customStreamingRpcUri, autoConnectOnStartup)
         {

--- a/Runtime/codebase/SolanaWalletAdapterWebGL/SolanaWalletAdapterWebGL.cs
+++ b/Runtime/codebase/SolanaWalletAdapterWebGL/SolanaWalletAdapterWebGL.cs
@@ -1,9 +1,8 @@
-﻿using System;
-using System.Runtime.InteropServices;
-using System.Threading.Tasks;
-using AOT;
+﻿using AOT;
 using Solana.Unity.Rpc.Models;
 using Solana.Unity.Wallet;
+using System;
+using System.Threading.Tasks;
 using UnityEngine;
 
 // ReSharper disable once CheckNamespace
@@ -211,6 +210,7 @@ namespace Solana.Unity.SDK
         [MonoPInvokeCallback(typeof(Action<string>))]
         public static void OnTransactionSigned(string transaction)
         {
+            SolanaWalletAdapter.TriggerUserApprovedTransaction(transaction != null);
             if (transaction == null)
             {
                 _signedTransactionTaskCompletionSource.TrySetException(new Exception("Transaction signing cancelled"));
@@ -228,6 +228,7 @@ namespace Solana.Unity.SDK
         [MonoPInvokeCallback(typeof(Action<string>))]
         public static void OnAllTransactionsSigned(string transactions)
         {
+            SolanaWalletAdapter.TriggerUserApprovedTransaction(transactions != null);
             if (transactions == null)
             {
                 _signedAllTransactionsTaskCompletionSource.TrySetException(new Exception("Transactions signing cancelled"));
@@ -252,6 +253,7 @@ namespace Solana.Unity.SDK
         [MonoPInvokeCallback(typeof(Action<string>))]
         public static void OnMessageSigned(string signature)
         {
+            SolanaWalletAdapter.TriggerUserApprovedTransaction(signature != null);
             if (signature == null)
             {
                 _signedMessageTaskCompletionSource.TrySetException(new Exception("Message signing cancelled"));

--- a/Runtime/codebase/WalletBase.cs
+++ b/Runtime/codebase/WalletBase.cs
@@ -253,10 +253,11 @@ namespace Solana.Unity.SDK
         (
             Transaction transaction,
             bool skipPreflight = false,
-            Commitment commitment = Commitment.Confirmed)
+            Commitment commitment = Commitment.Confirmed,
+            IRpcClient customClient = null)
         {
             var signedTransaction = await SignTransaction(transaction);
-            return await ActiveRpcClient.SendTransactionAsync(
+            return await (customClient ?? ActiveRpcClient).SendTransactionAsync(
                 Convert.ToBase64String(signedTransaction.Serialize()),
                 skipPreflight: skipPreflight, preFlightCommitment: commitment);
         }


### PR DESCRIPTION
| Status |   Type   | Core Change |
| Ready | Feature |         No         |

## Commit 1 — `customClient` on `SignAndSendTransaction` (e.g. `d07eab0`)

- **`WalletBase.SignAndSendTransaction`** now accepts an optional **`IRpcClient customClient`**. When provided, submission uses that client; otherwise behavior is unchanged (`ActiveRpcClient`).
- **Rationale:** Lets callers (including **Ephemeral Rollup / custom RPC** scenarios) submit signed transactions to a specific endpoint instead of only the wallet’s active client.

## Commit 2 — **Detect transaction decline** (e.g. `0727202`)

This commit builds on the **`UserApprovedTransaction`** / **`TriggerUserApprovedTransaction(bool)`** by **signaling declines and failures**, not only successful approvals.

### Behavior

- When a **transaction** or **message** signing flow ends with an **error**, **empty payload**, or other **deeplink failure** (e.g. user dismisses wallet, error string returned, missing `data`), adapters call **`TriggerUserApprovedTransaction(false)`** so listeners can treat it as **declined or failed** in the same frame as success paths use **`true`**.
- Aligns **Phantom deep link**, **WebGL**, and **Solana Mobile** flows so integrations can **distinguish “user approved” vs “user declined / error”** without guessing from logs alone.

### Files involved in commit 2

- `Runtime/codebase/DeepLinkWallets/PhantomDeepLink.cs` — decline/error paths for transaction and message signing callbacks.
- `Runtime/codebase/SolanaWalletAdapterWebGL/SolanaWalletAdapterWebGL.cs` — matching behavior where WebGL reports cancel/error.
- `Runtime/codebase/SolanaMobileStack/SolanaMobileWalletAdapter.cs` — transaction path (and any message-signing parity if included).
- `Runtime/codebase/SolanaWalletAdapter.cs` — shared event/API if touched.

### Why it matters

- **UI/state:** Games and apps can **clear loading state**, show **“cancelled”** messaging, or **retry** when the wallet returns an error or the user backs out.
- **Consistency:** Reduces **platform drift** (one stack firing events on failure, another silent).

---

## Deploy / integration notes

- **Subscribers** to `UserApprovedTransaction` should expect **`false`** not only for “declined” but for **any** failed or incomplete signing callback where the adapter triggers it (treat as **non-success**).
- No change to **wire formats** or **RPC**; this is **adapter signaling** (plus commit 1’s optional **`customClient`** for send).