### PR TITLE
Fix/mwa keep connection alive auth token restore

### DIFF
--- a/Runtime/codebase/SolanaMobileStack/Interfaces/IAdapterOperations.cs
+++ b/Runtime/codebase/SolanaMobileStack/Interfaces/IAdapterOperations.cs
@@ -13,6 +13,10 @@ public interface IAdapterOperations
     [Preserve]
     public Task<AuthorizationResult> Reauthorize(Uri identityUri, Uri iconUri, string identityName, string authToken);
     [Preserve]
+    Task Deauthorize(string authToken);
+    [Preserve]
+    Task<CapabilitiesResult> GetCapabilities();
+    [Preserve]
     public Task<SignedResult> SignTransactions(IEnumerable<byte[]> transactions);
     [Preserve]
     public Task<SignedResult> SignMessages(IEnumerable<byte[]> messages, IEnumerable<byte[]> addresses);

--- a/Runtime/codebase/SolanaMobileStack/Interfaces/IAdapterOperations.cs
+++ b/Runtime/codebase/SolanaMobileStack/Interfaces/IAdapterOperations.cs
@@ -13,9 +13,9 @@ public interface IAdapterOperations
     [Preserve]
     public Task<AuthorizationResult> Reauthorize(Uri identityUri, Uri iconUri, string identityName, string authToken);
     [Preserve]
-    Task Deauthorize(string authToken);
+    public Task Deauthorize(string authToken);
     [Preserve]
-    Task<CapabilitiesResult> GetCapabilities();
+    public Task<CapabilitiesResult> GetCapabilities();
     [Preserve]
     public Task<SignedResult> SignTransactions(IEnumerable<byte[]> transactions);
     [Preserve]

--- a/Runtime/codebase/SolanaMobileStack/JsonRpcClient/Responses/CapabilitiesResult.cs
+++ b/Runtime/codebase/SolanaMobileStack/JsonRpcClient/Responses/CapabilitiesResult.cs
@@ -7,7 +7,7 @@ using UnityEngine.Scripting;
 public class CapabilitiesResult
 {
     [JsonProperty("supports_clone_authorization")]
-    public bool SupportsCloneAuthorization { get; set; }
+    public bool? SupportsCloneAuthorization { get; set; }
 
     [JsonProperty("max_transactions_per_request")]
     public int? MaxTransactionsPerRequest { get; set; }

--- a/Runtime/codebase/SolanaMobileStack/JsonRpcClient/Responses/CapabilitiesResult.cs
+++ b/Runtime/codebase/SolanaMobileStack/JsonRpcClient/Responses/CapabilitiesResult.cs
@@ -1,0 +1,20 @@
+using Newtonsoft.Json;
+using UnityEngine.Scripting;
+
+// ReSharper disable once CheckNamespace
+
+[Preserve]
+public class CapabilitiesResult
+{
+    [JsonProperty("supports_clone_authorization")]
+    public bool SupportsCloneAuthorization { get; set; }
+
+    [JsonProperty("max_transactions_per_request")]
+    public int? MaxTransactionsPerRequest { get; set; }
+
+    [JsonProperty("max_messages_per_request")]
+    public int? MaxMessagesPerRequest { get; set; }
+
+    [JsonProperty("supported_transaction_versions")]
+    public string[] SupportedTransactionVersions { get; set; }
+}

--- a/Runtime/codebase/SolanaMobileStack/JsonRpcClient/Responses/CapabilitiesResult.cs.meta
+++ b/Runtime/codebase/SolanaMobileStack/JsonRpcClient/Responses/CapabilitiesResult.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: a0d47396ccea425489e0d0cd2dce7bbd

--- a/Runtime/codebase/SolanaMobileStack/MobileWalletAdapterClient.cs
+++ b/Runtime/codebase/SolanaMobileStack/MobileWalletAdapterClient.cs
@@ -44,6 +44,12 @@ public class MobileWalletAdapterClient: JsonRpc20Client, IAdapterOperations, IMe
 
         return SendRequest<AuthorizationResult>(request);
     }
+
+    public async Task Deauthorize(string authToken)
+    {
+        var request = PrepareDeauthorizeRequest(authToken);
+        await SendRequest<object>(request);
+    }
     
     public Task<SignedResult> SignTransactions(IEnumerable<byte[]> transactions)
     {
@@ -80,6 +86,21 @@ public class MobileWalletAdapterClient: JsonRpc20Client, IAdapterOperations, IMe
                     Name = name
                 },
                 Cluster = cluster
+            },
+            Id = NextMessageId()
+        };
+        return request;
+    }
+
+    private JsonRequest PrepareDeauthorizeRequest(string authToken)
+    {
+        var request = new JsonRequest
+        {
+            JsonRpc = "2.0",
+            Method = "deauthorize",
+            Params = new JsonRequest.JsonRequestParams
+            {
+                AuthToken = authToken
             },
             Id = NextMessageId()
         };

--- a/Runtime/codebase/SolanaMobileStack/MobileWalletAdapterClient.cs
+++ b/Runtime/codebase/SolanaMobileStack/MobileWalletAdapterClient.cs
@@ -50,6 +50,12 @@ public class MobileWalletAdapterClient: JsonRpc20Client, IAdapterOperations, IMe
         var request = PrepareDeauthorizeRequest(authToken);
         await SendRequest<object>(request);
     }
+
+    public Task<CapabilitiesResult> GetCapabilities()
+    {
+        var request = PrepareGetCapabilitiesRequest();
+        return SendRequest<CapabilitiesResult>(request);
+    }
     
     public Task<SignedResult> SignTransactions(IEnumerable<byte[]> transactions)
     {
@@ -102,6 +108,18 @@ public class MobileWalletAdapterClient: JsonRpc20Client, IAdapterOperations, IMe
             {
                 AuthToken = authToken
             },
+            Id = NextMessageId()
+        };
+        return request;
+    }
+
+    private JsonRequest PrepareGetCapabilitiesRequest()
+    {
+        var request = new JsonRequest
+        {
+            JsonRpc = "2.0",
+            Method = "get_capabilities",
+            Params = null,
             Id = NextMessageId()
         };
         return request;

--- a/Runtime/codebase/SolanaMobileStack/MobileWalletAdapterClient.cs
+++ b/Runtime/codebase/SolanaMobileStack/MobileWalletAdapterClient.cs
@@ -48,7 +48,7 @@ public class MobileWalletAdapterClient: JsonRpc20Client, IAdapterOperations, IMe
     public async Task Deauthorize(string authToken)
     {
         var request = PrepareDeauthorizeRequest(authToken);
-        await SendRequest<object>(request);
+        var response = await SendRequest<object>(request);
         if (response != null && response.Failed)
         {
             Debug.LogWarning($"[MWA] Deauthorize RPC returned error: {response.Error?.Message}");

--- a/Runtime/codebase/SolanaMobileStack/MobileWalletAdapterClient.cs
+++ b/Runtime/codebase/SolanaMobileStack/MobileWalletAdapterClient.cs
@@ -12,6 +12,8 @@ using UnityEngine.Scripting;
 public class MobileWalletAdapterClient: JsonRpc20Client, IAdapterOperations, IMessageReceiver
 {
     
+    private const string JsonRpcVersion = "2.0";
+    
     private int _mNextMessageId = 1;
 
     public MobileWalletAdapterClient(IMessageSender messageSender) : base(messageSender)
@@ -81,7 +83,7 @@ public class MobileWalletAdapterClient: JsonRpc20Client, IAdapterOperations, IMe
         }
         var request = new JsonRequest
         {
-            JsonRpc = "2.0",
+            JsonRpc = JsonRpcVersion,
             Method = method,
             Params = new JsonRequest.JsonRequestParams
             {
@@ -102,7 +104,7 @@ public class MobileWalletAdapterClient: JsonRpc20Client, IAdapterOperations, IMe
     {
         var request = new JsonRequest
         {
-            JsonRpc = "2.0",
+            JsonRpc = JsonRpcVersion,
             Method = "deauthorize",
             Params = new JsonRequest.JsonRequestParams
             {
@@ -117,7 +119,7 @@ public class MobileWalletAdapterClient: JsonRpc20Client, IAdapterOperations, IMe
     {
         var request = new JsonRequest
         {
-            JsonRpc = "2.0",
+            JsonRpc = JsonRpcVersion,
             Method = "get_capabilities",
             Params = new JsonRequest.JsonRequestParams(),
             Id = NextMessageId()
@@ -129,7 +131,7 @@ public class MobileWalletAdapterClient: JsonRpc20Client, IAdapterOperations, IMe
     {
         var request = new JsonRequest
         {
-            JsonRpc = "2.0",
+            JsonRpc = JsonRpcVersion,
             Method = "sign_transactions",
             Params = new JsonRequest.JsonRequestParams
             {
@@ -144,7 +146,7 @@ public class MobileWalletAdapterClient: JsonRpc20Client, IAdapterOperations, IMe
     {
         var request = new JsonRequest
         {
-            JsonRpc = "2.0",
+            JsonRpc = JsonRpcVersion,
             Method = "sign_messages",
             Params = new JsonRequest.JsonRequestParams
             {

--- a/Runtime/codebase/SolanaMobileStack/MobileWalletAdapterClient.cs
+++ b/Runtime/codebase/SolanaMobileStack/MobileWalletAdapterClient.cs
@@ -47,10 +47,10 @@ public class MobileWalletAdapterClient: JsonRpc20Client, IAdapterOperations, IMe
         return SendRequest<AuthorizationResult>(request);
     }
 
-    public async Task Deauthorize(string authToken)
+    public Task Deauthorize(string authToken)
     {
         var request = PrepareDeauthorizeRequest(authToken);
-        await SendRequest<object>(request);
+        return SendRequest<object>(request);
     }
 
     public Task<CapabilitiesResult> GetCapabilities()

--- a/Runtime/codebase/SolanaMobileStack/MobileWalletAdapterClient.cs
+++ b/Runtime/codebase/SolanaMobileStack/MobileWalletAdapterClient.cs
@@ -48,11 +48,7 @@ public class MobileWalletAdapterClient: JsonRpc20Client, IAdapterOperations, IMe
     public async Task Deauthorize(string authToken)
     {
         var request = PrepareDeauthorizeRequest(authToken);
-        var response = await SendRequest<object>(request);
-        if (response != null && response.Failed)
-        {
-            Debug.LogWarning($"[MWA] Deauthorize RPC returned error: {response.Error?.Message}");
-        }
+        await SendRequest<object>(request);
     }
 
     public Task<CapabilitiesResult> GetCapabilities()

--- a/Runtime/codebase/SolanaMobileStack/MobileWalletAdapterClient.cs
+++ b/Runtime/codebase/SolanaMobileStack/MobileWalletAdapterClient.cs
@@ -49,6 +49,10 @@ public class MobileWalletAdapterClient: JsonRpc20Client, IAdapterOperations, IMe
     {
         var request = PrepareDeauthorizeRequest(authToken);
         await SendRequest<object>(request);
+        if (response != null && response.Failed)
+        {
+            Debug.LogWarning($"[MWA] Deauthorize RPC returned error: {response.Error?.Message}");
+        }
     }
 
     public Task<CapabilitiesResult> GetCapabilities()
@@ -119,7 +123,7 @@ public class MobileWalletAdapterClient: JsonRpc20Client, IAdapterOperations, IMe
         {
             JsonRpc = "2.0",
             Method = "get_capabilities",
-            Params = null,
+            Params = new JsonRequest.JsonRequestParams(),
             Id = NextMessageId()
         };
         return request;

--- a/Runtime/codebase/SolanaMobileStack/SolanaMobileWalletAdapter.cs
+++ b/Runtime/codebase/SolanaMobileStack/SolanaMobileWalletAdapter.cs
@@ -60,7 +60,8 @@ namespace Solana.Unity.SDK
                 string authToken = PlayerPrefs.GetString("authToken", null);
                 if (!pk.IsNullOrEmpty() && !authToken.IsNullOrEmpty())
                 {
-                    using var reauthorizeScenario = new LocalAssociationScenario();
+                    // TODO: change to using var after PR #260 merges (IDisposable not yet on LocalAssociationScenario)
+                    var reauthorizeScenario = new LocalAssociationScenario();
                     var reauthorizeResult = await reauthorizeScenario.StartAndExecute(
                         new List<Action<IAdapterOperations>>
                         {
@@ -193,7 +194,8 @@ namespace Solana.Unity.SDK
                 return;
             }
 
-            using var localAssociationScenario = new LocalAssociationScenario();
+            // TODO: change to using var after PR #260 merges (IDisposable not yet on LocalAssociationScenario)
+            var localAssociationScenario = new LocalAssociationScenario();
             var result = await localAssociationScenario.StartAndExecute(
                 new List<Action<IAdapterOperations>>
                 {

--- a/Runtime/codebase/SolanaMobileStack/SolanaMobileWalletAdapter.cs
+++ b/Runtime/codebase/SolanaMobileStack/SolanaMobileWalletAdapter.cs
@@ -71,12 +71,20 @@ namespace Solana.Unity.SDK
                                     new Uri(_walletOptions.identityUri),
                                     new Uri(_walletOptions.iconUri, UriKind.Relative),
                                     _walletOptions.name, authToken);
-                                _authToken = reauth.AuthToken;
+                                if (reauth != null && !string.IsNullOrEmpty(reauth.AuthToken))
+                                {
+                                    _authToken = reauth.AuthToken;
+                                }
                             }
                         }
                     );
                     if (reauthorizeResult.WasSuccessful)
                     {
+                        if (!string.IsNullOrEmpty(_authToken))
+                        {
+                            PlayerPrefs.SetString("authToken", _authToken);
+                            PlayerPrefs.Save();
+                        }
                         return new Account(string.Empty, new PublicKey(pk));
                     }
                     PlayerPrefs.DeleteKey("pk");

--- a/Runtime/codebase/SolanaMobileStack/SolanaMobileWalletAdapter.cs
+++ b/Runtime/codebase/SolanaMobileStack/SolanaMobileWalletAdapter.cs
@@ -25,6 +25,9 @@ namespace Solana.Unity.SDK
     [Obsolete("Use SolanaWalletAdapter class instead, which is the cross platform wrapper.")]
     public class SolanaMobileWalletAdapter : WalletBase
     {
+        private const string PrefKeyPublicKey = "solana_sdk.mwa.public_key";
+        private const string PrefKeyAuthToken = "solana_sdk.mwa.auth_token";
+        
         private readonly SolanaMobileWalletAdapterOptions _walletOptions;
         
         private Transaction _currentTransaction;
@@ -56,8 +59,8 @@ namespace Solana.Unity.SDK
         {
             if (_walletOptions.keepConnectionAlive)
             {
-                string pk = PlayerPrefs.GetString("pk", null);
-                string authToken = PlayerPrefs.GetString("authToken", null);
+                string pk = PlayerPrefs.GetString(PrefKeyPublicKey, null);
+                string authToken = PlayerPrefs.GetString(PrefKeyAuthToken, null);
                 if (!pk.IsNullOrEmpty() && !authToken.IsNullOrEmpty())
                 {
                     string reauthPublicKey = null;
@@ -91,20 +94,20 @@ namespace Solana.Unity.SDK
                         }
                         else
                         {
-                            PlayerPrefs.SetString("authToken", _authToken);
+                            PlayerPrefs.SetString(PrefKeyAuthToken, _authToken);
                             PlayerPrefs.Save();
                             var resolvedKey = !string.IsNullOrEmpty(reauthPublicKey) ? reauthPublicKey : pk;
                             return new Account(string.Empty, new PublicKey(resolvedKey));
                         }
                     }
                     // Reauthorize failed or returned empty token - clear cached credentials
-                    PlayerPrefs.DeleteKey("pk");
-                    PlayerPrefs.DeleteKey("authToken");
+                    PlayerPrefs.DeleteKey(PrefKeyPublicKey);
+                    PlayerPrefs.DeleteKey(PrefKeyAuthToken);
                     PlayerPrefs.Save();
                 }
                 else if (!pk.IsNullOrEmpty())
                 {
-                    PlayerPrefs.DeleteKey("pk");
+                    PlayerPrefs.DeleteKey(PrefKeyPublicKey);
                     PlayerPrefs.Save();
                 }
             }
@@ -136,8 +139,8 @@ namespace Solana.Unity.SDK
             var publicKey = new PublicKey(authorization.PublicKey);
             if (_walletOptions.keepConnectionAlive)
             {
-                PlayerPrefs.SetString("pk", publicKey.ToString());
-                PlayerPrefs.SetString("authToken", _authToken);
+                PlayerPrefs.SetString(PrefKeyPublicKey, publicKey.ToString());
+                PlayerPrefs.SetString(PrefKeyAuthToken, _authToken);
                 PlayerPrefs.Save();
             }
             return new Account(string.Empty, publicKey);
@@ -153,7 +156,7 @@ namespace Solana.Unity.SDK
         protected override async Task<Transaction[]> _SignAllTransactions(Transaction[] transactions)
         {
             if (_authToken.IsNullOrEmpty() && _walletOptions.keepConnectionAlive)
-                _authToken = PlayerPrefs.GetString("authToken", null);
+                _authToken = PlayerPrefs.GetString(PrefKeyAuthToken, null);
 
             var cluster = RPCNameMap[(int)RpcCluster];
             SignedResult res = null;
@@ -201,7 +204,7 @@ namespace Solana.Unity.SDK
             _authToken = authorization.AuthToken;
             if (_walletOptions.keepConnectionAlive)
             {
-                PlayerPrefs.SetString("authToken", _authToken);
+                PlayerPrefs.SetString(PrefKeyAuthToken, _authToken);
                 PlayerPrefs.Save();
             }
             return res.SignedPayloads.Select(transaction => Transaction.Deserialize(transaction)).ToArray();
@@ -211,9 +214,9 @@ namespace Solana.Unity.SDK
         public override void Logout()
         {
             base.Logout();
-            PlayerPrefs.DeleteKey("pk");
+            PlayerPrefs.DeleteKey(PrefKeyPublicKey);
             _authToken = null;
-            PlayerPrefs.DeleteKey("authToken");
+            PlayerPrefs.DeleteKey(PrefKeyAuthToken);
             PlayerPrefs.Save();
         }
 
@@ -221,7 +224,7 @@ namespace Solana.Unity.SDK
         {
             string authToken = _authToken;
             if (authToken.IsNullOrEmpty())
-                authToken = PlayerPrefs.GetString("authToken", null);
+                authToken = PlayerPrefs.GetString(PrefKeyAuthToken, null);
 
             if (!authToken.IsNullOrEmpty())
             {
@@ -304,10 +307,10 @@ namespace Solana.Unity.SDK
         public override async Task<byte[]> SignMessage(byte[] message)
         {
             if (_authToken.IsNullOrEmpty() && _walletOptions.keepConnectionAlive)
-                _authToken = PlayerPrefs.GetString("authToken", null);
+                _authToken = PlayerPrefs.GetString(PrefKeyAuthToken, null);
 
             string cachedPk = Account?.PublicKey?.ToString()
-                ?? PlayerPrefs.GetString("pk", null);
+                ?? PlayerPrefs.GetString(PrefKeyPublicKey, null);
             if (string.IsNullOrEmpty(cachedPk))
                 throw new Exception("[MWA] Cannot sign message: no account available");
 
@@ -360,7 +363,7 @@ namespace Solana.Unity.SDK
             _authToken = authorization.AuthToken;
             if (_walletOptions.keepConnectionAlive)
             {
-                PlayerPrefs.SetString("authToken", _authToken);
+                PlayerPrefs.SetString(PrefKeyAuthToken, _authToken);
                 PlayerPrefs.Save();
             }
             return signedMessages.SignedPayloadsBytes[0];

--- a/Runtime/codebase/SolanaMobileStack/SolanaMobileWalletAdapter.cs
+++ b/Runtime/codebase/SolanaMobileStack/SolanaMobileWalletAdapter.cs
@@ -34,6 +34,9 @@ namespace Solana.Unity.SDK
         private readonly WalletBase _internalWallet;
         private string _authToken;
 
+        public event Action OnWalletDisconnected;
+        public event Action OnWalletReconnected;
+
         public SolanaMobileWalletAdapter(
             SolanaMobileWalletAdapterOptions solanaWalletOptions,
             RpcCluster rpcCluster = RpcCluster.DevNet, 
@@ -173,6 +176,50 @@ namespace Solana.Unity.SDK
             _authToken = null;
             PlayerPrefs.DeleteKey("authToken");
             PlayerPrefs.Save();
+        }
+
+        public async Task DisconnectWallet()
+        {
+            string authToken = _authToken;
+            if (authToken.IsNullOrEmpty())
+                authToken = PlayerPrefs.GetString("authToken", null);
+
+            if (authToken.IsNullOrEmpty())
+            {
+                Logout();
+                OnWalletDisconnected?.Invoke();
+                return;
+            }
+
+            using var localAssociationScenario = new LocalAssociationScenario();
+            var result = await localAssociationScenario.StartAndExecute(
+                new List<Action<IAdapterOperations>>
+                {
+                    async client =>
+                    {
+                        await client.Deauthorize(authToken);
+                    }
+                }
+            );
+            if (!result.WasSuccessful)
+            {
+                Debug.LogError(result.Error.Message);
+            }
+            Logout();
+            OnWalletDisconnected?.Invoke();
+        }
+
+        public async Task ReconnectWallet()
+        {
+            try
+            {
+                await Login();
+                OnWalletReconnected?.Invoke();
+            }
+            catch (Exception e)
+            {
+                Debug.LogError(e.Message);
+            }
         }
 
         public override async Task<byte[]> SignMessage(byte[] message)

--- a/Runtime/codebase/SolanaMobileStack/SolanaMobileWalletAdapter.cs
+++ b/Runtime/codebase/SolanaMobileStack/SolanaMobileWalletAdapter.cs
@@ -54,7 +54,36 @@ namespace Solana.Unity.SDK
             if (_walletOptions.keepConnectionAlive)
             {
                 string pk = PlayerPrefs.GetString("pk", null);
-                if (!pk.IsNullOrEmpty()) return new Account(string.Empty, new PublicKey(pk));
+                string authToken = PlayerPrefs.GetString("authToken", null);
+                if (!pk.IsNullOrEmpty() && !authToken.IsNullOrEmpty())
+                {
+                    using var reauthorizeScenario = new LocalAssociationScenario();
+                    var reauthorizeResult = await reauthorizeScenario.StartAndExecute(
+                        new List<Action<IAdapterOperations>>
+                        {
+                            async client =>
+                            {
+                                var reauth = await client.Reauthorize(
+                                    new Uri(_walletOptions.identityUri),
+                                    new Uri(_walletOptions.iconUri, UriKind.Relative),
+                                    _walletOptions.name, authToken);
+                                _authToken = reauth.AuthToken;
+                            }
+                        }
+                    );
+                    if (reauthorizeResult.WasSuccessful)
+                    {
+                        return new Account(string.Empty, new PublicKey(pk));
+                    }
+                    PlayerPrefs.DeleteKey("pk");
+                    PlayerPrefs.DeleteKey("authToken");
+                    PlayerPrefs.Save();
+                }
+                else if (!pk.IsNullOrEmpty())
+                {
+                    PlayerPrefs.DeleteKey("pk");
+                    PlayerPrefs.Save();
+                }
             }
             AuthorizationResult authorization = null;
             var localAssociationScenario = new LocalAssociationScenario();
@@ -81,6 +110,8 @@ namespace Solana.Unity.SDK
             if (_walletOptions.keepConnectionAlive)
             {
                 PlayerPrefs.SetString("pk", publicKey.ToString());
+                PlayerPrefs.SetString("authToken", _authToken);
+                PlayerPrefs.Save();
             }
             return new Account(string.Empty, publicKey);
         }

--- a/Runtime/codebase/SolanaMobileStack/SolanaMobileWalletAdapter.cs
+++ b/Runtime/codebase/SolanaMobileStack/SolanaMobileWalletAdapter.cs
@@ -194,6 +194,10 @@ namespace Solana.Unity.SDK
             {
                 throw new Exception("[MWA] SignAllTransactions: authorization was not populated");
             }
+            if (res == null)
+            {
+                throw new Exception("[MWA] SignAllTransactions: signed payloads were not populated");
+            }
             _authToken = authorization.AuthToken;
             if (_walletOptions.keepConnectionAlive)
             {
@@ -348,6 +352,10 @@ namespace Solana.Unity.SDK
             if (authorization == null)
             {
                 throw new Exception("[MWA] SignMessage: authorization was not populated");
+            }
+            if (signedMessages == null)
+            {
+                throw new Exception("[MWA] SignMessage: signed payloads were not populated");
             }
             _authToken = authorization.AuthToken;
             if (_walletOptions.keepConnectionAlive)

--- a/Runtime/codebase/SolanaMobileStack/SolanaMobileWalletAdapter.cs
+++ b/Runtime/codebase/SolanaMobileStack/SolanaMobileWalletAdapter.cs
@@ -135,13 +135,16 @@ namespace Solana.Unity.SDK
             {
                 throw new Exception("[MWA] Login: authorization was not populated");
             }
-            _authToken = authorization.AuthToken;
             var publicKey = new PublicKey(authorization.PublicKey);
-            if (_walletOptions.keepConnectionAlive)
+            if (!string.IsNullOrEmpty(authorization.AuthToken))
             {
-                PlayerPrefs.SetString(PrefKeyPublicKey, publicKey.ToString());
-                PlayerPrefs.SetString(PrefKeyAuthToken, _authToken);
-                PlayerPrefs.Save();
+                _authToken = authorization.AuthToken;
+                if (_walletOptions.keepConnectionAlive)
+                {
+                    PlayerPrefs.SetString(PrefKeyPublicKey, publicKey.ToString());
+                    PlayerPrefs.SetString(PrefKeyAuthToken, _authToken);
+                    PlayerPrefs.Save();
+                }
             }
             return new Account(string.Empty, publicKey);
         }

--- a/Runtime/codebase/SolanaMobileStack/SolanaMobileWalletAdapter.cs
+++ b/Runtime/codebase/SolanaMobileStack/SolanaMobileWalletAdapter.cs
@@ -201,11 +201,14 @@ namespace Solana.Unity.SDK
             {
                 throw new Exception("[MWA] SignAllTransactions: signed payloads were not populated");
             }
-            _authToken = authorization.AuthToken;
-            if (_walletOptions.keepConnectionAlive)
+            if (!string.IsNullOrEmpty(authorization.AuthToken))
             {
-                PlayerPrefs.SetString(PrefKeyAuthToken, _authToken);
-                PlayerPrefs.Save();
+                _authToken = authorization.AuthToken;
+                if (_walletOptions.keepConnectionAlive)
+                {
+                    PlayerPrefs.SetString(PrefKeyAuthToken, _authToken);
+                    PlayerPrefs.Save();
+                }
             }
             return res.SignedPayloads.Select(transaction => Transaction.Deserialize(transaction)).ToArray();
         }
@@ -360,11 +363,14 @@ namespace Solana.Unity.SDK
             {
                 throw new Exception("[MWA] SignMessage: signed payloads were not populated");
             }
-            _authToken = authorization.AuthToken;
-            if (_walletOptions.keepConnectionAlive)
+            if (!string.IsNullOrEmpty(authorization.AuthToken))
             {
-                PlayerPrefs.SetString(PrefKeyAuthToken, _authToken);
-                PlayerPrefs.Save();
+                _authToken = authorization.AuthToken;
+                if (_walletOptions.keepConnectionAlive)
+                {
+                    PlayerPrefs.SetString(PrefKeyAuthToken, _authToken);
+                    PlayerPrefs.Save();
+                }
             }
             return signedMessages.SignedPayloadsBytes[0];
         }

--- a/Runtime/codebase/SolanaMobileStack/SolanaMobileWalletAdapter.cs
+++ b/Runtime/codebase/SolanaMobileStack/SolanaMobileWalletAdapter.cs
@@ -84,13 +84,20 @@ namespace Solana.Unity.SDK
                     );
                     if (reauthorizeResult.WasSuccessful)
                     {
-                        if (!string.IsNullOrEmpty(_authToken))
+                        if (string.IsNullOrEmpty(_authToken))
+                        {
+                            // Reauthorize RPC succeeded but wallet returned no token - treat as failure
+                            PlayerPrefs.DeleteKey("pk");
+                            PlayerPrefs.DeleteKey("authToken");
+                            PlayerPrefs.Save();
+                        }
+                        else
                         {
                             PlayerPrefs.SetString("authToken", _authToken);
                             PlayerPrefs.Save();
+                            var resolvedKey = !string.IsNullOrEmpty(reauthPublicKey) ? reauthPublicKey : pk;
+                            return new Account(string.Empty, new PublicKey(resolvedKey));
                         }
-                        var resolvedKey = !string.IsNullOrEmpty(reauthPublicKey) ? reauthPublicKey : pk;
-                        return new Account(string.Empty, new PublicKey(resolvedKey));
                     }
                     PlayerPrefs.DeleteKey("pk");
                     PlayerPrefs.DeleteKey("authToken");
@@ -278,7 +285,7 @@ namespace Solana.Unity.SDK
             }
             if (capabilities == null)
             {
-                Debug.LogWarning("[MWA] GetCapabilities succeeded but returned null");
+                throw new Exception("[MWA] GetCapabilities RPC succeeded but returned no data");
             }
             return capabilities;
         }

--- a/Runtime/codebase/SolanaMobileStack/SolanaMobileWalletAdapter.cs
+++ b/Runtime/codebase/SolanaMobileStack/SolanaMobileWalletAdapter.cs
@@ -60,6 +60,7 @@ namespace Solana.Unity.SDK
                 string authToken = PlayerPrefs.GetString("authToken", null);
                 if (!pk.IsNullOrEmpty() && !authToken.IsNullOrEmpty())
                 {
+                    string reauthPublicKey = null;
                     // TODO: change to using var after PR #260 merges (IDisposable not yet on LocalAssociationScenario)
                     var reauthorizeScenario = new LocalAssociationScenario();
                     var reauthorizeResult = await reauthorizeScenario.StartAndExecute(
@@ -74,6 +75,9 @@ namespace Solana.Unity.SDK
                                 if (reauth != null && !string.IsNullOrEmpty(reauth.AuthToken))
                                 {
                                     _authToken = reauth.AuthToken;
+                                    reauthPublicKey = reauth.PublicKey != null
+                                        ? new PublicKey(reauth.PublicKey).ToString()
+                                        : null;
                                 }
                             }
                         }
@@ -85,7 +89,8 @@ namespace Solana.Unity.SDK
                             PlayerPrefs.SetString("authToken", _authToken);
                             PlayerPrefs.Save();
                         }
-                        return new Account(string.Empty, new PublicKey(pk));
+                        var resolvedKey = !string.IsNullOrEmpty(reauthPublicKey) ? reauthPublicKey : pk;
+                        return new Account(string.Empty, new PublicKey(resolvedKey));
                     }
                     PlayerPrefs.DeleteKey("pk");
                     PlayerPrefs.DeleteKey("authToken");
@@ -137,7 +142,7 @@ namespace Solana.Unity.SDK
 
         protected override async Task<Transaction[]> _SignAllTransactions(Transaction[] transactions)
         {
-            if (_authToken.IsNullOrEmpty())
+            if (_authToken.IsNullOrEmpty() && _walletOptions.keepConnectionAlive)
                 _authToken = PlayerPrefs.GetString("authToken", null);
 
             var cluster = RPCNameMap[(int)RpcCluster];
@@ -176,6 +181,11 @@ namespace Solana.Unity.SDK
                 throw new Exception(result.Error.Message);
             }
             _authToken = authorization.AuthToken;
+            if (_walletOptions.keepConnectionAlive)
+            {
+                PlayerPrefs.SetString("authToken", _authToken);
+                PlayerPrefs.Save();
+            }
             return res.SignedPayloads.Select(transaction => Transaction.Deserialize(transaction)).ToArray();
         }
 
@@ -275,8 +285,13 @@ namespace Solana.Unity.SDK
 
         public override async Task<byte[]> SignMessage(byte[] message)
         {
-            if (_authToken.IsNullOrEmpty())
+            if (_authToken.IsNullOrEmpty() && _walletOptions.keepConnectionAlive)
                 _authToken = PlayerPrefs.GetString("authToken", null);
+
+            string cachedPk = Account?.PublicKey?.ToString()
+                ?? PlayerPrefs.GetString("pk", null);
+            if (string.IsNullOrEmpty(cachedPk))
+                throw new Exception("[MWA] Cannot sign message: no account available");
 
             SignedResult signedMessages = null;
             var localAssociationScenario = new LocalAssociationScenario();
@@ -306,7 +321,7 @@ namespace Solana.Unity.SDK
                     {
                         signedMessages = await client.SignMessages(
                             messages: new List<byte[]> { message },
-                            addresses: new List<byte[]> { Account.PublicKey.KeyBytes }
+                            addresses: new List<byte[]> { new PublicKey(cachedPk).KeyBytes }
                         );
                     }
                 }
@@ -317,6 +332,11 @@ namespace Solana.Unity.SDK
                 throw new Exception(result.Error.Message);
             }
             _authToken = authorization.AuthToken;
+            if (_walletOptions.keepConnectionAlive)
+            {
+                PlayerPrefs.SetString("authToken", _authToken);
+                PlayerPrefs.Save();
+            }
             return signedMessages.SignedPayloadsBytes[0];
         }
 

--- a/Runtime/codebase/SolanaMobileStack/SolanaMobileWalletAdapter.cs
+++ b/Runtime/codebase/SolanaMobileStack/SolanaMobileWalletAdapter.cs
@@ -139,6 +139,8 @@ namespace Solana.Unity.SDK
         {
             base.Logout();
             PlayerPrefs.DeleteKey("pk");
+            _authToken = null;
+            PlayerPrefs.DeleteKey("authToken");
             PlayerPrefs.Save();
         }
 

--- a/Runtime/codebase/SolanaMobileStack/SolanaMobileWalletAdapter.cs
+++ b/Runtime/codebase/SolanaMobileStack/SolanaMobileWalletAdapter.cs
@@ -53,6 +53,26 @@ namespace Solana.Unity.SDK
             {
                 throw new Exception("SolanaMobileWalletAdapter can only be used on Android");
             }
+            MigrateLegacyPrefKeys();
+        }
+
+        private static void MigrateLegacyPrefKeys()
+        {
+            const string legacyPk = "pk";
+            const string legacyAuthToken = "authToken";
+
+            if (!PlayerPrefs.HasKey(legacyPk) && !PlayerPrefs.HasKey(legacyAuthToken))
+                return;
+
+            if (PlayerPrefs.HasKey(legacyPk) && !PlayerPrefs.HasKey(PrefKeyPublicKey))
+                PlayerPrefs.SetString(PrefKeyPublicKey, PlayerPrefs.GetString(legacyPk));
+
+            if (PlayerPrefs.HasKey(legacyAuthToken) && !PlayerPrefs.HasKey(PrefKeyAuthToken))
+                PlayerPrefs.SetString(PrefKeyAuthToken, PlayerPrefs.GetString(legacyAuthToken));
+
+            PlayerPrefs.DeleteKey(legacyPk);
+            PlayerPrefs.DeleteKey(legacyAuthToken);
+            PlayerPrefs.Save();
         }
 
         protected override async Task<Account> _Login(string password = null)

--- a/Runtime/codebase/SolanaMobileStack/SolanaMobileWalletAdapter.cs
+++ b/Runtime/codebase/SolanaMobileStack/SolanaMobileWalletAdapter.cs
@@ -299,7 +299,7 @@ namespace Solana.Unity.SDK
             }
             catch (Exception e)
             {
-                Debug.LogError(e.Message);
+                Debug.LogError($"[MWA] ReconnectWallet failed: {e}");
                 throw;
             }
         }

--- a/Runtime/codebase/SolanaMobileStack/SolanaMobileWalletAdapter.cs
+++ b/Runtime/codebase/SolanaMobileStack/SolanaMobileWalletAdapter.cs
@@ -237,11 +237,13 @@ namespace Solana.Unity.SDK
                 else
                 {
                     Debug.LogWarning("[MWA] ReconnectWallet: Login returned null, not firing OnWalletReconnected");
+                    throw new Exception("ReconnectWallet failed: Login returned null");
                 }
             }
             catch (Exception e)
             {
                 Debug.LogError(e.Message);
+                throw;
             }
         }
 

--- a/Runtime/codebase/SolanaMobileStack/SolanaMobileWalletAdapter.cs
+++ b/Runtime/codebase/SolanaMobileStack/SolanaMobileWalletAdapter.cs
@@ -87,9 +87,7 @@ namespace Solana.Unity.SDK
                         if (string.IsNullOrEmpty(_authToken))
                         {
                             // Reauthorize RPC succeeded but wallet returned no token - treat as failure
-                            PlayerPrefs.DeleteKey("pk");
-                            PlayerPrefs.DeleteKey("authToken");
-                            PlayerPrefs.Save();
+                            // Fall through to cleanup below
                         }
                         else
                         {
@@ -99,6 +97,7 @@ namespace Solana.Unity.SDK
                             return new Account(string.Empty, new PublicKey(resolvedKey));
                         }
                     }
+                    // Reauthorize failed or returned empty token - clear cached credentials
                     PlayerPrefs.DeleteKey("pk");
                     PlayerPrefs.DeleteKey("authToken");
                     PlayerPrefs.Save();
@@ -128,6 +127,10 @@ namespace Solana.Unity.SDK
             {
                 Debug.LogError(result.Error.Message);
                 throw new Exception(result.Error.Message);
+            }
+            if (authorization == null)
+            {
+                throw new Exception("[MWA] Login: authorization was not populated");
             }
             _authToken = authorization.AuthToken;
             var publicKey = new PublicKey(authorization.PublicKey);
@@ -186,6 +189,10 @@ namespace Solana.Unity.SDK
             {
                 Debug.LogError(result.Error.Message);
                 throw new Exception(result.Error.Message);
+            }
+            if (authorization == null)
+            {
+                throw new Exception("[MWA] SignAllTransactions: authorization was not populated");
             }
             _authToken = authorization.AuthToken;
             if (_walletOptions.keepConnectionAlive)
@@ -337,6 +344,10 @@ namespace Solana.Unity.SDK
             {
                 Debug.LogError(result.Error.Message);
                 throw new Exception(result.Error.Message);
+            }
+            if (authorization == null)
+            {
+                throw new Exception("[MWA] SignMessage: authorization was not populated");
             }
             _authToken = authorization.AuthToken;
             if (_walletOptions.keepConnectionAlive)

--- a/Runtime/codebase/SolanaMobileStack/SolanaMobileWalletAdapter.cs
+++ b/Runtime/codebase/SolanaMobileStack/SolanaMobileWalletAdapter.cs
@@ -266,6 +266,10 @@ namespace Solana.Unity.SDK
                 Debug.LogError(result.Error.Message);
                 throw new Exception(result.Error.Message);
             }
+            if (capabilities == null)
+            {
+                Debug.LogWarning("[MWA] GetCapabilities succeeded but returned null");
+            }
             return capabilities;
         }
 

--- a/Runtime/codebase/SolanaMobileStack/SolanaMobileWalletAdapter.cs
+++ b/Runtime/codebase/SolanaMobileStack/SolanaMobileWalletAdapter.cs
@@ -195,28 +195,32 @@ namespace Solana.Unity.SDK
             if (authToken.IsNullOrEmpty())
                 authToken = PlayerPrefs.GetString("authToken", null);
 
-            if (authToken.IsNullOrEmpty())
+            if (!authToken.IsNullOrEmpty())
             {
-                Logout();
-                OnWalletDisconnected?.Invoke();
-                return;
-            }
-
-            // TODO: change to using var after PR #260 merges (IDisposable not yet on LocalAssociationScenario)
-            var localAssociationScenario = new LocalAssociationScenario();
-            var result = await localAssociationScenario.StartAndExecute(
-                new List<Action<IAdapterOperations>>
+                try
                 {
-                    async client =>
+                    // TODO: change to using var after PR #260 merges (IDisposable not yet on LocalAssociationScenario)
+                    var localAssociationScenario = new LocalAssociationScenario();
+                    var result = await localAssociationScenario.StartAndExecute(
+                        new List<Action<IAdapterOperations>>
+                        {
+                            async client =>
+                            {
+                                await client.Deauthorize(authToken);
+                            }
+                        }
+                    );
+                    if (!result.WasSuccessful)
                     {
-                        await client.Deauthorize(authToken);
+                        Debug.LogWarning($"[MWA] Deauthorize returned error: {result.Error.Message}");
                     }
                 }
-            );
-            if (!result.WasSuccessful)
-            {
-                Debug.LogError(result.Error.Message);
+                catch (Exception e)
+                {
+                    Debug.LogWarning($"[MWA] Deauthorize transport failed (best-effort): {e}");
+                }
             }
+
             Logout();
             OnWalletDisconnected?.Invoke();
         }
@@ -225,13 +229,42 @@ namespace Solana.Unity.SDK
         {
             try
             {
-                await Login();
-                OnWalletReconnected?.Invoke();
+                var account = await Login();
+                if (account != null)
+                {
+                    OnWalletReconnected?.Invoke();
+                }
+                else
+                {
+                    Debug.LogWarning("[MWA] ReconnectWallet: Login returned null, not firing OnWalletReconnected");
+                }
             }
             catch (Exception e)
             {
                 Debug.LogError(e.Message);
             }
+        }
+
+        public async Task<CapabilitiesResult> GetCapabilities()
+        {
+            CapabilitiesResult capabilities = null;
+            // TODO: change to using var after PR #260 merges (IDisposable not yet on LocalAssociationScenario)
+            var localAssociationScenario = new LocalAssociationScenario();
+            var result = await localAssociationScenario.StartAndExecute(
+                new List<Action<IAdapterOperations>>
+                {
+                    async client =>
+                    {
+                        capabilities = await client.GetCapabilities();
+                    }
+                }
+            );
+            if (!result.WasSuccessful)
+            {
+                Debug.LogError(result.Error.Message);
+                throw new Exception(result.Error.Message);
+            }
+            return capabilities;
         }
 
         public override async Task<byte[]> SignMessage(byte[] message)

--- a/Runtime/codebase/SolanaMobileStack/SolanaMobileWalletAdapter.cs
+++ b/Runtime/codebase/SolanaMobileStack/SolanaMobileWalletAdapter.cs
@@ -128,6 +128,8 @@ namespace Solana.Unity.SDK
 
         protected override async Task<Transaction[]> _SignAllTransactions(Transaction[] transactions)
         {
+            if (_authToken.IsNullOrEmpty())
+                _authToken = PlayerPrefs.GetString("authToken", null);
 
             var cluster = RPCNameMap[(int)RpcCluster];
             SignedResult res = null;
@@ -224,6 +226,9 @@ namespace Solana.Unity.SDK
 
         public override async Task<byte[]> SignMessage(byte[] message)
         {
+            if (_authToken.IsNullOrEmpty())
+                _authToken = PlayerPrefs.GetString("authToken", null);
+
             SignedResult signedMessages = null;
             var localAssociationScenario = new LocalAssociationScenario();
             AuthorizationResult authorization = null;

--- a/Runtime/codebase/SolanaWalletAdapter.cs
+++ b/Runtime/codebase/SolanaWalletAdapter.cs
@@ -95,6 +95,7 @@ namespace Solana.Unity.SDK
             }
             if (_internalWallet != null)
                 throw new NotImplementedException();
+            // No internal wallet configured - nothing to disconnect
         }
 
         public async Task ReconnectWallet()
@@ -109,6 +110,19 @@ namespace Solana.Unity.SDK
                 throw new NotImplementedException();
         }
 
+        /// <summary>
+        /// Queries the connected wallet's supported features and limits.
+        /// </summary>
+        /// <returns>
+        /// A <see cref="CapabilitiesResult"/> containing wallet feature limits
+        /// (MaxTransactionsPerRequest, MaxMessagesPerRequest,
+        /// SupportedTransactionVersions, SupportsCloneAuthorization)
+        /// when running on Android with a connected SolanaMobileWalletAdapter.
+        /// Returns null when _internalWallet is null or not configured.
+        /// Throws <see cref="NotImplementedException"/> when _internalWallet
+        /// is non-null but is not a SolanaMobileWalletAdapter (e.g. WebGL,
+        /// iOS). Callers must handle the null return case.
+        /// </returns>
         public async Task<CapabilitiesResult> GetCapabilities()
         {
             var mobileAdapter = _internalWallet as SolanaMobileWalletAdapter;

--- a/Runtime/codebase/SolanaWalletAdapter.cs
+++ b/Runtime/codebase/SolanaWalletAdapter.cs
@@ -108,6 +108,7 @@ namespace Solana.Unity.SDK
             }
             if (_internalWallet != null)
                 throw new NotImplementedException();
+            // No internal wallet configured - nothing to reconnect
         }
 
         /// <summary>

--- a/Runtime/codebase/SolanaWalletAdapter.cs
+++ b/Runtime/codebase/SolanaWalletAdapter.cs
@@ -20,6 +20,9 @@ namespace Solana.Unity.SDK
     {
         private readonly WalletBase _internalWallet;
 
+        public event Action OnWalletDisconnected;
+        public event Action OnWalletReconnected;
+
         public SolanaWalletAdapter(SolanaWalletAdapterOptions options, RpcCluster rpcCluster = RpcCluster.DevNet, string customRpcUri = null, string customStreamingRpcUri = null, bool autoConnectOnStartup = false) : base(rpcCluster, customRpcUri, customStreamingRpcUri, autoConnectOnStartup)
         {
             #if UNITY_ANDROID
@@ -32,6 +35,14 @@ namespace Solana.Unity.SDK
             #pragma warning disable CS0618
             _internalWallet = new PhantomDeepLink(options.phantomWalletOptions, rpcCluster, customRpcUri, customStreamingRpcUri, autoConnectOnStartup);
             #else
+            #endif
+
+            #if UNITY_ANDROID
+            if (_internalWallet is SolanaMobileWalletAdapter mobileAdapter)
+            {
+                mobileAdapter.OnWalletDisconnected += () => OnWalletDisconnected?.Invoke();
+                mobileAdapter.OnWalletReconnected += () => OnWalletReconnected?.Invoke();
+            }
             #endif
         }
 
@@ -96,6 +107,16 @@ namespace Solana.Unity.SDK
             }
             if (_internalWallet != null)
                 throw new NotImplementedException();
+        }
+
+        public async Task<CapabilitiesResult> GetCapabilities()
+        {
+            var mobileAdapter = _internalWallet as SolanaMobileWalletAdapter;
+            if (mobileAdapter != null)
+                return await mobileAdapter.GetCapabilities();
+            if (_internalWallet != null)
+                throw new NotImplementedException();
+            return null;
         }
     }
 }

--- a/Runtime/codebase/SolanaWalletAdapter.cs
+++ b/Runtime/codebase/SolanaWalletAdapter.cs
@@ -73,5 +73,29 @@ namespace Solana.Unity.SDK
             base.Logout();
             _internalWallet?.Logout();
         }
+
+        public async Task DisconnectWallet()
+        {
+            var mobileAdapter = _internalWallet as SolanaMobileWalletAdapter;
+            if (mobileAdapter != null)
+            {
+                await mobileAdapter.DisconnectWallet();
+                return;
+            }
+            if (_internalWallet != null)
+                throw new NotImplementedException();
+        }
+
+        public async Task ReconnectWallet()
+        {
+            var mobileAdapter = _internalWallet as SolanaMobileWalletAdapter;
+            if (mobileAdapter != null)
+            {
+                await mobileAdapter.ReconnectWallet();
+                return;
+            }
+            if (_internalWallet != null)
+                throw new NotImplementedException();
+        }
     }
 }


### PR DESCRIPTION
> ⚠️ This PR does not modify LocalAssociationScenario.cs. New 
> LocalAssociationScenario usages are marked with TODO comments to 
> switch to `using var` after PR #260 merges (which adds IDisposable). 
> This PR is compatible with PR #260 and will require a trivial rebase 
> on lines 63, 202, and 251 (var to using var) after #260 merges.

| Status | Type | ⚠️ Core Change | Issue |
| :---: | :---: | :---: | :--: |
| Ready | Bug | Yes | [#267](https://github.com/magicblock-labs/Solana.Unity-SDK/issues/267) |

## Problem

While building Unity Android games on Solana (CrossyRoad and SolRacer), 
I found that after an explicit logout, the wallet silently reconnected 
on the next app launch without showing an authorization prompt. The 
player tapped Logout but the game behaved as if they never did.

Debugging traced this to three gaps in SolanaMobileWalletAdapter:

1. Logout() never set _authToken = null. Within the same session, 
   signing operations after logout would attempt Reauthorize() with 
   a token the user intended to revoke.

2. keepConnectionAlive = true restored Account from PlayerPrefs["pk"] 
   without verifying the auth session. On process restart, _authToken 
   was null, so the first SignTransaction() call triggered a full 
   Authorize() popup during gameplay instead of at login time.

3. IAdapterOperations had no Deauthorize() method. The wallet app was 
   never notified of logout. Auth tokens remained valid indefinitely.

## Solution

**Lifecycle fixes (closes #267):**
- Added _authToken = null and PlayerPrefs.DeleteKey("authToken") to Logout(). base.Logout() is called first, then auth state is cleared
- Persist authToken alongside pk on successful Authorize()
- In _Login(), attempt Reauthorize() with cached token before returning 
  cached Account. Fall through to full Authorize() if token is invalid 
  or missing.
- Restore _authToken from PlayerPrefs at top of _SignAllTransactions() 
  and SignMessage() to handle cold start correctly

**New RPC operations (MWA spec):**
- Deauthorize(string authToken): sends deauthorize JSON-RPC to wallet
- GetCapabilities(): queries wallet feature limits, returns 
  CapabilitiesResult with MaxTransactionsPerRequest, 
  MaxMessagesPerRequest, SupportedTransactionVersions, 
  SupportsCloneAuthorization

**New lifecycle API:**
- DisconnectWallet(): reads cached token with PlayerPrefs fallback 
  for cold start, sends Deauthorize RPC, clears all auth state. 
  Deauthorize is best-effort, local cleanup always runs.
- ReconnectWallet(): attempts silent reauthorize with cached token, 
  fires OnWalletReconnected on success
- OnWalletDisconnected and OnWalletReconnected events on both 
  SolanaMobileWalletAdapter and SolanaWalletAdapter
- GetCapabilities() passthrough on SolanaWalletAdapter

## Before & After Screenshots

**BEFORE** -> wallet silently reconnects after explicit logout:

Open app
Connect wallet -- Seeker authorization prompt appears -- Approve
Close app
Reopen app -- No prompt -- wallet silently reconnected
Logout -- token never actually revoked on wallet side

**AFTER** -> auth cache correctly invalidated on logout:


https://github.com/user-attachments/assets/5f0706e0-86e2-4fed-8bfc-452125ff9ee5



Open app
Connect wallet -- Seeker authorization prompt appears -- Approve
Close app without logout
Reopen app -- Silent reauthorize -- Connected instantly -- No popup
Logout -- Deauthorize RPC sent to Seeker -- cache cleared
Reopen app -- Seeker authorization prompt appears -- Fresh approval required

Tested on Android (Seeker wallet via Mobile Wallet Adapter) in:
- CrossyRoad: https://github.com/JoshhSandhu/CrossyRoad
- SolRacer (private, unreleased)

## Other changes

- CapabilitiesResult.cs added alongside existing response models 
  following same Preserve and JsonProperty conventions
- Events fire after state is fully updated, not before
- DisconnectWallet() has try/catch so transport failure never blocks 
  local logout
- All new changes are backward compatible, no existing constructor 
  signatures or public method signatures changed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Wallet disconnect/reconnect actions with events for connection-state changes.
  * Ability to query wallet capabilities (clone-authorization support, transaction/message limits, supported transaction versions).
  * Explicit deauthorization operation to revoke stored session tokens.

* **Chores / Behavior**
  * Improved session persistence and signing flows: lazy-loading/reuse of stored auth tokens, reauthorization flow, persisting refreshed tokens, and explicit clearing of tokens on logout or failed reauth.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->