### PR TITLE
feat(WalletBase): add SignMessage(string) convenience overload

### DIFF
--- a/Runtime/codebase/WalletBaseExtensions.cs
+++ b/Runtime/codebase/WalletBaseExtensions.cs
@@ -1,0 +1,30 @@
+using System;
+using System.Text;
+using System.Threading.Tasks;
+
+// ReSharper disable once CheckNamespace
+namespace Solana.Unity.SDK
+{
+    /// <summary>
+    /// Convenience extensions for <see cref="IWalletBase"/>.
+    /// </summary>
+    public static class WalletBaseExtensions
+    {
+        /// <summary>
+        /// Sign a UTF-8 encoded string message. The string is encoded to bytes
+        /// and forwarded to <see cref="IWalletBase.SignMessage(byte[])"/>.
+        /// </summary>
+        /// <param name="wallet">The wallet to sign with.</param>
+        /// <param name="message">The string message to sign.</param>
+        /// <returns>The signature bytes.</returns>
+        /// <exception cref="ArgumentNullException">
+        /// Thrown when <paramref name="wallet"/> or <paramref name="message"/> is null.
+        /// </exception>
+        public static Task<byte[]> SignMessage(this IWalletBase wallet, string message)
+        {
+            if (wallet == null) throw new ArgumentNullException(nameof(wallet));
+            if (message == null) throw new ArgumentNullException(nameof(message));
+            return wallet.SignMessage(Encoding.UTF8.GetBytes(message));
+        }
+    }
+}

--- a/Runtime/codebase/WalletBaseExtensions.cs.meta
+++ b/Runtime/codebase/WalletBaseExtensions.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: e1c5b3d9f8a24e76b4c8d2e5f6a9c1b3


### PR DESCRIPTION
  | Status | Type | ⚠️  Core Change | Issue |                                                                                                                              
  | :---: | :---: | :---: | :--: |                                                                                                                                          
  | Ready | Feature | Yes | [#273](https://github.com/magicblock-labs/Solana.Unity-SDK/issues/273) |                                                                        
                                                                                                                                                                            
  ## Problem                                                                                                                                                                
                                                                                                                                                                            
  `SignMessage()` only accepts `byte[]`. Every caller must manually convert strings via `Encoding.UTF8.GetBytes()` before signing, adding unnecessary boilerplate for the   
  most common use case — signing human-readable messages.
                                                                                                                                                                            
  Discovered while building a Unity MWA example app on Solana Seeker hardware with Seed Vault                                                                               
  ([unity-solana-mwa-example](https://github.com/mstevens843/unity-solana-mwa-example)). Documented as Point 6 in #273.
                                                                                                                                                                            
  ## Solution                                                                                                                                                             

  Added `SignMessage(string message)` overload to `IWalletBase` and `WalletBase` that handles UTF-8 encoding internally, delegating to the existing `SignMessage(byte[])`.  
   
  All derived wallet classes (`InGameWallet`, `SolanaMobileWalletAdapter`, `SolanaWalletAdapterWebGL`, `PhantomDeepLink`, `SolanaWalletAdapter`) inherit the new overload   
  automatically — zero changes required in implementations.                                                                                                               
                                                                                                                                                                            
  ## Before & After Screenshots                                                                                                                                           

  **BEFORE:**

      var payload = Encoding.UTF8.GetBytes("Hello from Unity");                                                                                                             
      var signature = await Web3.Wallet.SignMessage(payload);
                                                                                                                                                                            
  **AFTER:**                                                                                                                                                              
                                                                                                                                                                            
      var signature = await Web3.Wallet.SignMessage("Hello from Unity");                                                                                                  

  ## Other changes (e.g. bug fixes, small refactors)                                                                                                                        
   
  None. Purely additive — no existing signatures or behavior modified.                                                                                                      
                                                                                                                                                                          
  ## Deploy Notes                                                                                                                                                           
                                                                                                                                                                          
  No new scripts or dependencies. Drop-in enhancement to existing API surface.   

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Sign plain text directly (UTF-8) — users can sign strings without manual conversion.
* **Improvements**
  * Null input is validated and yields a clear argument error for ambiguous nulls.
  * Behavior remains backward-compatible with existing binary signing workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->