### PR TITLE
Feat(test)/unity test framework

### DIFF
--- a/Runtime/codebase/SolanaMobileStack/Crypto/ECDSASignatures.cs
+++ b/Runtime/codebase/SolanaMobileStack/Crypto/ECDSASignatures.cs
@@ -118,7 +118,7 @@ public static class EcdsaSignatures
         byte[] derSignature,
         int derOffset) {
         
-        Assert.IsTrue(p1363Offset > 0);
+        Assert.IsTrue(p1363Offset >= 0);
         Assert.IsTrue(p1363ComponentDerIntLength is > 1 and <= P256P1363ComponentLen + 1);
         
         derSignature[derOffset] = P256DerSignatureComponentPrefixType;

--- a/Runtime/codebase/SolanaMobileStack/MobileWalletAdapterSession.cs
+++ b/Runtime/codebase/SolanaMobileStack/MobileWalletAdapterSession.cs
@@ -150,7 +150,7 @@ public class MobileWalletAdapterSession
     {
         if (_encryptionKey == null)
         {
-            const string e = "Cannot encrypt, no session key has been established";
+            const string e = "Cannot decrypt, no session key has been established";
             Debug.LogError(e);
             throw new InvalidOperationException(e);
         }

--- a/Tests.meta
+++ b/Tests.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 554d7a8341af39843b18cce3a5ff03e6
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Tests/EditMode.meta
+++ b/Tests/EditMode.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 072036a5c660dc44485d211d261a32ae
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Tests/EditMode/Crypto.meta
+++ b/Tests/EditMode/Crypto.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: c9262f07467029c4c8d90e6e90fe8b2a
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Tests/EditMode/Crypto/EcdsaSignaturesTests.cs
+++ b/Tests/EditMode/Crypto/EcdsaSignaturesTests.cs
@@ -1,0 +1,140 @@
+using NUnit.Framework;
+using System;
+using Org.BouncyCastle.Asn1.Sec;
+using Org.BouncyCastle.Crypto.Generators;
+using Org.BouncyCastle.Crypto.Parameters;
+using Org.BouncyCastle.Security;
+
+// ReSharper disable once CheckNamespace
+namespace Solana.Unity.SDK.Tests.EditMode.Crypto
+{
+    /// <summary>
+    /// Edit mode tests for the EcdsaSignatures helpers.
+    /// These only exercise the crypto conversion logic, so they don't need Android.
+    /// </summary>
+    public class EcdsaSignaturesTests
+    {
+       
+        // Helpers
+        private static ECPublicKeyParameters GenerateP256PublicKey()
+        {
+            var gen = new ECKeyPairGenerator();
+            var curve = SecNamedCurves.GetByName("secp256r1");
+            var domainParams = new ECDomainParameters(curve.Curve, curve.G, curve.N, curve.H);
+            gen.Init(new ECKeyGenerationParameters(domainParams, new SecureRandom()));
+            var keyPair = gen.GenerateKeyPair();
+            return (ECPublicKeyParameters)keyPair.Public;
+        }
+
+        private static byte[] GenerateValidP1363Signature()
+        {
+            // Use a real signature so the round-trip test is working with realistic input.
+            var session = new MobileWalletAdapterSession();
+            var helloReq = session.CreateHelloReq();
+            // HELLO_REQ is [65-byte public key | 64-byte P1363 signature].
+            var p1363 = new byte[64];
+            Array.Copy(helloReq, 65, p1363, 0, 64);
+            return p1363;
+        }
+
+       
+        // DER <-> P1363 round-trip
+        [Test]
+        public void ConvertDerToP1363_ThenBackToDer_RoundTrip_PreservesSignature()
+        {
+            // Start with a valid P1363 signature.
+            byte[] originalP1363 = GenerateValidP1363Signature();
+
+            // Convert to DER and back again.
+            byte[] der = EcdsaSignatures.ConvertEcp256SignatureP1363ToDer(originalP1363, 0);
+            byte[] roundTrippedP1363 = EcdsaSignatures.ConvertEcp256SignatureDeRtoP1363(der, 0);
+
+            // We should end up with the exact same 64-byte signature.
+            Assert.AreEqual(64, roundTrippedP1363.Length,
+                "P1363 signature must always be exactly 64 bytes");
+            Assert.AreEqual(originalP1363, roundTrippedP1363,
+                "Round-tripped P1363 signature must be byte-for-byte identical to the original");
+        }
+
+       
+        // DER input validation
+        [Test]
+        public void ConvertDerToP1363_ThrowsArgumentException_WhenBufferTooShort()
+        {
+            // Too short to even contain the DER prefix.
+            var tooShort = new byte[1] { 0x30 };
+
+            // Act & Assert
+            var ex = Assert.Throws<ArgumentException>(() =>
+                EcdsaSignatures.ConvertEcp256SignatureDeRtoP1363(tooShort, 0));
+
+            StringAssert.Contains("too short", ex.Message,
+                "Exception message should mention buffer is too short");
+        }
+
+        [Test]
+        public void ConvertDerToP1363_ThrowsArgumentException_WhenTypeByte_IsWrong()
+        {
+            // Same shape, but the DER type byte is wrong.
+            var wrongType = new byte[] { 0x31, 0x44, 0x02, 0x20 };
+
+            // Act & Assert
+            var ex = Assert.Throws<ArgumentException>(() =>
+                EcdsaSignatures.ConvertEcp256SignatureDeRtoP1363(wrongType, 0));
+
+            StringAssert.Contains("invalid type", ex.Message,
+                "Exception message should mention invalid type");
+        }
+
+       
+        // P-256 public key round-trip
+        [Test]
+        public void EncodeDecodeP256PublicKey_RoundTrip_PreservesCoordinates()
+        {
+            // Arrange
+            var originalKey = GenerateP256PublicKey();
+
+            // Act
+            byte[] encoded = EcdsaSignatures.EncodeP256PublicKey(originalKey);
+            ECPublicKeyParameters decoded = EcdsaSignatures.DecodeP256PublicKey(encoded);
+
+            // Uncompressed point format is 0x04 + 32-byte X + 32-byte Y.
+            Assert.AreEqual(65, encoded.Length,
+                "Encoded public key must be 65 bytes (uncompressed point format)");
+            Assert.AreEqual((byte)0x04, encoded[0],
+                "First byte must be 0x04 for uncompressed EC point");
+
+            var originalX = originalKey.Q.AffineXCoord.ToBigInteger();
+            var originalY = originalKey.Q.AffineYCoord.ToBigInteger();
+            var decodedX = decoded.Q.AffineXCoord.ToBigInteger();
+            var decodedY = decoded.Q.AffineYCoord.ToBigInteger();
+
+            Assert.AreEqual(originalX, decodedX, "X coordinate must survive encode/decode");
+            Assert.AreEqual(originalY, decodedY, "Y coordinate must survive encode/decode");
+        }
+
+        [Test]
+        public void DecodeP256PublicKey_ThrowsArgumentException_WhenInputTooShort()
+        {
+            // Definitely shorter than a valid uncompressed key.
+            var tooShort = new byte[10];
+            tooShort[0] = 0x04;
+
+            // Act & Assert
+            Assert.Throws<ArgumentException>(() =>
+                EcdsaSignatures.DecodeP256PublicKey(tooShort));
+        }
+
+        [Test]
+        public void DecodeP256PublicKey_ThrowsArgumentException_WhenPrefixByte_IsWrong()
+        {
+            // Right length, wrong point prefix.
+            var wrongPrefix = new byte[65];
+            wrongPrefix[0] = 0x02;
+
+            // Act & Assert
+            Assert.Throws<ArgumentException>(() =>
+                EcdsaSignatures.DecodeP256PublicKey(wrongPrefix));
+        }
+    }
+}

--- a/Tests/EditMode/Crypto/EcdsaSignaturesTests.cs.meta
+++ b/Tests/EditMode/Crypto/EcdsaSignaturesTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 9245366494c00974f9ab48602105d5ef

--- a/Tests/EditMode/Crypto/MobileWalletAdapterSessionTests.cs
+++ b/Tests/EditMode/Crypto/MobileWalletAdapterSessionTests.cs
@@ -96,7 +96,7 @@ namespace Solana.Unity.SDK.Tests.EditMode.Crypto
             var payload = new byte[64]; // arbitrary non-empty payload
 
             // The production code logs before it throws, so the test needs to allow that.
-            LogAssert.Expect(LogType.Error, "Cannot encrypt, no session key has been established");
+            LogAssert.Expect(LogType.Error, "Cannot decrypt, no session key has been established");
 
             // Act & Assert
             Assert.Throws<InvalidOperationException>(() =>

--- a/Tests/EditMode/Crypto/MobileWalletAdapterSessionTests.cs
+++ b/Tests/EditMode/Crypto/MobileWalletAdapterSessionTests.cs
@@ -1,0 +1,136 @@
+using NUnit.Framework;
+using System;
+using System.Text.RegularExpressions;
+using UnityEngine;
+using UnityEngine.TestTools;
+
+// ReSharper disable once CheckNamespace
+namespace Solana.Unity.SDK.Tests.EditMode.Crypto
+{
+    /// <summary>
+    /// Edit mode tests for MobileWalletAdapterSession.
+    /// These cover the session's pure crypto and encoding behavior without Android.
+    /// </summary>
+    public class MobileWalletAdapterSessionTests
+    {
+       
+        // AssociationToken format
+        [Test]
+        public void AssociationToken_IsValidBase64Url_NoStandardBase64Characters()
+        {
+            // Arrange
+            var session = new MobileWalletAdapterSession();
+
+            // Act
+            string token = session.AssociationToken;
+
+            // Base64Url output should avoid the characters that break URLs.
+            Assert.IsNotNull(token, "AssociationToken must not be null");
+            Assert.IsNotEmpty(token, "AssociationToken must not be empty");
+            Assert.IsFalse(token.Contains('+'),
+                "AssociationToken must not contain '+' (standard Base64 char, breaks URI)");
+            Assert.IsFalse(token.Contains('/'),
+                "AssociationToken must not contain '/' (standard Base64 char, breaks URI)");
+            Assert.IsFalse(token.Contains('='),
+                "AssociationToken must not contain '=' padding (breaks URI)");
+        }
+
+        [Test]
+        public void AssociationToken_OnlyContains_ValidBase64UrlCharacters()
+        {
+            // Arrange
+            var session = new MobileWalletAdapterSession();
+
+            // Act
+            string token = session.AssociationToken;
+
+            // Only URL-safe Base64 characters should be present.
+            var validBase64Url = new Regex(@"^[A-Za-z0-9\-_]+$");
+            Assert.IsTrue(validBase64Url.IsMatch(token),
+                $"AssociationToken '{token}' contains characters outside Base64Url alphabet");
+        }
+
+        [Test]
+        public void AssociationToken_IsDerivedFrom_PublicKeyBytes()
+        {
+            // Arrange
+            var session = new MobileWalletAdapterSession();
+
+            // Recreate the token from the raw public key bytes.
+            byte[] pubKeyBytes = session.PublicKeyBytes;
+            string expected = Convert.ToBase64String(pubKeyBytes)
+                .Split('=')[0]
+                .Replace('+', '-')
+                .Replace('/', '_');
+
+            // Assert
+            Assert.AreEqual(expected, session.AssociationToken,
+                "AssociationToken must be the Base64Url encoding of PublicKeyBytes");
+        }
+
+       
+        // Error paths before ECDH is set up
+        [Test]
+        public void EncryptSessionPayload_ThrowsInvalidOperationException_WhenNoSessionKeyEstablished()
+        {
+            // Fresh session; no shared key has been negotiated yet.
+            var session = new MobileWalletAdapterSession();
+            var payload = new byte[] { 0x01, 0x02, 0x03 };
+
+            // The production code logs before it throws, so the test needs to allow that.
+            LogAssert.Expect(LogType.Error, "Cannot encrypt, no session key has been established");
+
+            // Act & Assert
+            var ex = Assert.Throws<InvalidOperationException>(() =>
+                session.EncryptSessionPayload(payload));
+
+            StringAssert.Contains("no session key has been established", ex.Message,
+                "Exception message must mention that no session key has been established");
+        }
+
+        [Test]
+        public void DecryptSessionPayload_ThrowsInvalidOperationException_WhenNoSessionKeyEstablished()
+        {
+            // Fresh session; no shared key has been negotiated yet.
+            var session = new MobileWalletAdapterSession();
+            var payload = new byte[64]; // arbitrary non-empty payload
+
+            // The production code logs before it throws, so the test needs to allow that.
+            LogAssert.Expect(LogType.Error, "Cannot encrypt, no session key has been established");
+
+            // Act & Assert
+            Assert.Throws<InvalidOperationException>(() =>
+                session.DecryptSessionPayload(payload));
+        }
+
+       
+        // Public key shape
+        [Test]
+        public void PublicKeyBytes_IsUncompressedEcPoint_65Bytes()
+        {
+            // Arrange
+            var session = new MobileWalletAdapterSession();
+
+            // Act
+            byte[] pubKeyBytes = session.PublicKeyBytes;
+
+            // Assert
+            Assert.AreEqual(65, pubKeyBytes.Length,
+                "PublicKeyBytes must be 65 bytes (uncompressed EC point: 0x04 || X || Y)");
+            Assert.AreEqual((byte)0x04, pubKeyBytes[0],
+                "First byte of PublicKeyBytes must be 0x04 (uncompressed point marker)");
+        }
+
+        [Test]
+        public void TwoSessions_HaveDifferent_AssociationTokens()
+        {
+            // Each session should generate its own keypair.
+            var session1 = new MobileWalletAdapterSession();
+            var session2 = new MobileWalletAdapterSession();
+
+            // Assert
+            Assert.AreNotEqual(session1.AssociationToken, session2.AssociationToken,
+                "Two independent sessions must produce different AssociationTokens");
+        }
+    }
+}

--- a/Tests/EditMode/Crypto/MobileWalletAdapterSessionTests.cs.meta
+++ b/Tests/EditMode/Crypto/MobileWalletAdapterSessionTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 71ffba8b25573504a85e9190bcdf0778

--- a/Tests/EditMode/EditMode.asmdef
+++ b/Tests/EditMode/EditMode.asmdef
@@ -1,0 +1,23 @@
+{
+    "name": "Solana.Unity.SDK.Tests.EditMode",
+    "rootNamespace": "Solana.Unity.SDK.Tests.EditMode",
+    "references": [
+        "com.solana.unity_sdk",
+        "UnityEngine.TestRunner",
+        "UnityEditor.TestRunner"
+    ],
+    "includePlatforms": [
+        "Editor"
+    ],
+    "excludePlatforms": [],
+    "allowUnsafeCode": true,
+    "overrideReferences": true,
+    "precompiledReferences": [
+        "nunit.framework.dll",
+        "BouncyCastle.Cryptography.dll",
+        "Newtonsoft.Json.dll"
+    ],
+    "autoReferenced": false,
+    "defineConstraints": [],
+    "noEngineReferences": false
+}

--- a/Tests/EditMode/EditMode.asmdef
+++ b/Tests/EditMode/EditMode.asmdef
@@ -10,7 +10,7 @@
         "Editor"
     ],
     "excludePlatforms": [],
-    "allowUnsafeCode": true,
+    "allowUnsafeCode": false,
     "overrideReferences": true,
     "precompiledReferences": [
         "nunit.framework.dll",

--- a/Tests/EditMode/EditMode.asmdef.meta
+++ b/Tests/EditMode/EditMode.asmdef.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: cb50964cab2798645a6d875b0bf11648
+AssemblyDefinitionImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Tests/EditMode/JsonRpc.meta
+++ b/Tests/EditMode/JsonRpc.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 8f2775ea9a8b7d9459cc7ce38871faf7
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Tests/EditMode/JsonRpc/ResponseModelTests.cs
+++ b/Tests/EditMode/JsonRpc/ResponseModelTests.cs
@@ -1,0 +1,138 @@
+using NUnit.Framework;
+
+// ReSharper disable once CheckNamespace
+namespace Solana.Unity.SDK.Tests.EditMode.JsonRpc
+{
+    /// <summary>
+    /// Edit mode tests for the simple Response&lt;T&gt; flags and nested error model.
+    /// These are small checks, but a regression here would affect every caller.
+    /// </summary>
+    public class ResponseModelTests
+    {
+       
+        // Success and failure flags
+        [Test]
+        public void WasSuccessful_IsTrue_WhenError_IsNull()
+        {
+            // Arrange
+            var response = new Response<object>
+            {
+                JsonRpc = "2.0",
+                Id = 1,
+                Result = new object(),
+                Error = null
+            };
+
+            // Assert
+            Assert.IsTrue(response.WasSuccessful,
+                "WasSuccessful must be true when Error is null");
+        }
+
+       
+        // Failure flag
+        [Test]
+        public void Failed_IsTrue_WhenError_IsNotNull()
+        {
+            // Arrange
+            var response = new Response<object>
+            {
+                JsonRpc = "2.0",
+                Id = 1,
+                Result = null,
+                Error = new Response<object>.ResponseError
+                {
+                    Code = -32600,
+                    Message = "Invalid Request"
+                }
+            };
+
+            // Assert
+            Assert.IsTrue(response.Failed,
+                "Failed must be true when Error is not null");
+        }
+
+       
+        // The flags should never contradict each other
+        [Test]
+        public void WasSuccessful_And_Failed_AreNeverBothTrue()
+        {
+            // Success case
+            var successResponse = new Response<object> { Error = null };
+            // Failure case
+            var failResponse = new Response<object>
+            {
+                Error = new Response<object>.ResponseError { Code = -1, Message = "err" }
+            };
+
+            // These flags should be mutually exclusive.
+            Assert.IsFalse(successResponse.WasSuccessful && successResponse.Failed,
+                "WasSuccessful and Failed must not both be true (success response)");
+            Assert.IsFalse(failResponse.WasSuccessful && failResponse.Failed,
+                "WasSuccessful and Failed must not both be true (fail response)");
+        }
+
+       
+        // A few extra sanity checks
+        [Test]
+        public void WasSuccessful_IsFalse_WhenError_IsNotNull()
+        {
+            // Arrange
+            var response = new Response<object>
+            {
+                Error = new Response<object>.ResponseError { Code = -32601, Message = "Method not found" }
+            };
+
+            // Assert
+            Assert.IsFalse(response.WasSuccessful,
+                "WasSuccessful must be false when Error is not null");
+        }
+
+        [Test]
+        public void Failed_IsFalse_WhenError_IsNull()
+        {
+            // Arrange
+            var response = new Response<object> { Error = null };
+
+            // Assert
+            Assert.IsFalse(response.Failed,
+                "Failed must be false when Error is null");
+        }
+
+       
+        // ResponseError properties
+        [Test]
+        public void ResponseError_Properties_AreSetCorrectly()
+        {
+            // Arrange
+            var error = new Response<object>.ResponseError
+            {
+                Code = -32700,
+                Message = "Parse error"
+            };
+
+            // Assert
+            Assert.AreEqual(-32700, error.Code);
+            Assert.AreEqual("Parse error", error.Message);
+        }
+
+       
+        // Generic behavior
+        [Test]
+        public void Response_WorksWith_StringResult()
+        {
+            // Arrange
+            var response = new Response<string>
+            {
+                JsonRpc = "2.0",
+                Id = 42,
+                Result = "ok",
+                Error = null
+            };
+
+            // Assert
+            Assert.IsTrue(response.WasSuccessful);
+            Assert.AreEqual("ok", response.Result);
+            Assert.AreEqual(42, response.Id);
+        }
+    }
+}

--- a/Tests/EditMode/JsonRpc/ResponseModelTests.cs.meta
+++ b/Tests/EditMode/JsonRpc/ResponseModelTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 5c82dc44f888ec24d8f2cb7853dbdacb

--- a/Tests/EditMode/Mocks.meta
+++ b/Tests/EditMode/Mocks.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 0a72ff4341ca7a04f89c8d4eb8927c94
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Tests/EditMode/Mocks/MockMessageSender.cs
+++ b/Tests/EditMode/Mocks/MockMessageSender.cs
@@ -1,0 +1,27 @@
+using System.Collections.Generic;
+using Solana.Unity.SDK;
+
+// ReSharper disable once CheckNamespace
+namespace Solana.Unity.SDK.Tests.EditMode.Mocks
+{
+    /// <summary>
+    /// Simple test sender that records every message passed to Send().
+    /// Tests can inspect the captured payloads afterward.
+    /// </summary>
+    public class MockMessageSender : IMessageSender
+    {
+        public readonly List<byte[]> SentMessages = new List<byte[]>();
+
+        public void Send(byte[] message)
+        {
+            SentMessages.Add(message);
+        }
+
+        /// <summary>
+        /// Returns the latest message, or null if nothing has been sent yet.
+        /// </summary>
+        public byte[] LastMessage => SentMessages.Count > 0
+            ? SentMessages[SentMessages.Count - 1]
+            : null;
+    }
+}

--- a/Tests/EditMode/Mocks/MockMessageSender.cs
+++ b/Tests/EditMode/Mocks/MockMessageSender.cs
@@ -14,14 +14,16 @@ namespace Solana.Unity.SDK.Tests.EditMode.Mocks
 
         public void Send(byte[] message)
         {
-            SentMessages.Add(message);
+            SentMessages.Add(message == null ? null : (byte[])message.Clone());
         }
 
         /// <summary>
         /// Returns the latest message, or null if nothing has been sent yet.
         /// </summary>
         public byte[] LastMessage => SentMessages.Count > 0
-            ? SentMessages[SentMessages.Count - 1]
+            ? (SentMessages[SentMessages.Count - 1] == null
+                ? null
+                : (byte[])SentMessages[SentMessages.Count - 1].Clone())
             : null;
     }
 }

--- a/Tests/EditMode/Mocks/MockMessageSender.cs.meta
+++ b/Tests/EditMode/Mocks/MockMessageSender.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: e73cb75400b357342983ed85d555a713

--- a/Tests/EditMode/MwaClient.meta
+++ b/Tests/EditMode/MwaClient.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 3327273c6fb67514185722d233ab2ca9
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Tests/EditMode/MwaClient/MobileWalletAdapterClientTests.cs
+++ b/Tests/EditMode/MwaClient/MobileWalletAdapterClientTests.cs
@@ -1,0 +1,210 @@
+using NUnit.Framework;
+using System;
+using System.Text;
+using Newtonsoft.Json;
+using Solana.Unity.SDK.Tests.EditMode.Mocks;
+
+// ReSharper disable once CheckNamespace
+namespace Solana.Unity.SDK.Tests.EditMode.MwaClient
+{
+    /// <summary>
+    /// Edit mode tests for MobileWalletAdapterClient request building.
+    /// A mock sender lets us inspect the JSON payloads without a real socket.
+    /// </summary>
+    public class MobileWalletAdapterClientTests
+    {
+        private MockMessageSender _sender;
+        private MobileWalletAdapterClient _client;
+
+        [SetUp]
+        public void SetUp()
+        {
+            _sender = new MockMessageSender();
+            _client = new MobileWalletAdapterClient(_sender);
+        }
+
+       
+        // Helpers
+
+        /// <summary>
+        /// Reads the last message the client sent and deserializes it as a JsonRequest.
+        /// Right now these requests are still plain JSON at this stage of the flow.
+        /// If that ever changes, this helper will need to be updated too.
+        /// </summary>
+        private JsonRequest DecodeLastRequest()
+        {
+            Assert.IsNotNull(_sender.LastMessage, "No message was sent to MockMessageSender");
+            var json = Encoding.UTF8.GetString(_sender.LastMessage);
+            return JsonConvert.DeserializeObject<JsonRequest>(json);
+        }
+
+       
+        // Authorize request shape
+        [Test]
+        public void Authorize_SendsJsonRpc_WithCorrectMethod()
+        {
+            // Arrange
+            var identityUri = new Uri("https://example.com");
+            var iconUri = new Uri("/icon.png", UriKind.Relative);
+            const string identityName = "TestApp";
+            const string cluster = "mainnet-beta";
+
+            // Act
+            _ = _client.Authorize(identityUri, iconUri, identityName, cluster);
+
+            // Assert
+            var request = DecodeLastRequest();
+            Assert.AreEqual("authorize", request.Method,
+                "Method must be 'authorize'");
+        }
+
+        [Test]
+        public void Authorize_SendsJsonRpc_WithVersion2_0()
+        {
+            // Arrange
+            var identityUri = new Uri("https://example.com");
+
+            // Act
+            _ = _client.Authorize(identityUri, null, "TestApp", "mainnet-beta");
+
+            // Assert
+            var request = DecodeLastRequest();
+            Assert.AreEqual("2.0", request.JsonRpc,
+                "JsonRpc version must be '2.0'");
+        }
+
+        [Test]
+        public void Authorize_SendsJsonRpc_WithNonZeroId()
+        {
+            // Arrange
+            var identityUri = new Uri("https://example.com");
+
+            // Act
+            _ = _client.Authorize(identityUri, null, "TestApp", "mainnet-beta");
+
+            // Assert
+            var request = DecodeLastRequest();
+            Assert.Greater(request.Id, 0, "Request Id must be a positive integer");
+        }
+
+        [Test]
+        public void Authorize_SendsJsonRpc_WithIdentityName()
+        {
+            // Arrange
+            var identityUri = new Uri("https://example.com");
+            const string identityName = "CrossyRoad";
+
+            // Act
+            _ = _client.Authorize(identityUri, null, identityName, "mainnet-beta");
+
+            // Assert
+            var request = DecodeLastRequest();
+            Assert.AreEqual(identityName, request.Params.Identity.Name,
+                "Identity.Name must match the supplied identityName");
+        }
+
+        [Test]
+        public void Authorize_SendsJsonRpc_WithCorrectCluster()
+        {
+            // Arrange
+            var identityUri = new Uri("https://example.com");
+            const string cluster = "devnet";
+
+            // Act
+            _ = _client.Authorize(identityUri, null, "TestApp", cluster);
+
+            // Assert
+            var request = DecodeLastRequest();
+            Assert.AreEqual(cluster, request.Params.Cluster,
+                "Params.Cluster must match the supplied cluster string");
+        }
+
+        [Test]
+        public void Authorize_MessageIds_AreIncrementing()
+        {
+            // Arrange
+            var identityUri = new Uri("https://example.com");
+
+            // Act fire two requests
+            _ = _client.Authorize(identityUri, null, "TestApp", "mainnet-beta");
+            var firstJson = Encoding.UTF8.GetString(_sender.SentMessages[0]);
+            var firstRequest = JsonConvert.DeserializeObject<JsonRequest>(firstJson);
+
+            _ = _client.Authorize(identityUri, null, "TestApp", "mainnet-beta");
+            var secondJson = Encoding.UTF8.GetString(_sender.SentMessages[1]);
+            var secondRequest = JsonConvert.DeserializeObject<JsonRequest>(secondJson);
+
+            // Assert
+            Assert.AreEqual(firstRequest.Id + 1, secondRequest.Id,
+                "Each successive request must have an Id one greater than the previous");
+        }
+
+       
+        // Authorize validation
+        [Test]
+        public void Authorize_ThrowsArgumentException_WhenIdentityUri_IsRelative()
+        {
+            // Relative identity URIs are not allowed by the MWA spec.
+            var relativeUri = new Uri("/relative/path", UriKind.Relative);
+
+            // Act & Assert
+            Assert.Throws<ArgumentException>(() =>
+                _client.Authorize(relativeUri, null, "TestApp", "mainnet-beta"),
+                "Authorize must throw ArgumentException when identityUri is relative");
+        }
+
+        [Test]
+        public void Authorize_DoesNotThrow_WhenIdentityUri_IsNull()
+        {
+            // Null is allowed here, so this should stay a valid call.
+            Assert.DoesNotThrow(() =>
+                _client.Authorize(null, null, "TestApp", "mainnet-beta"));
+        }
+
+        [Test]
+        public void Authorize_ThrowsArgumentException_WhenIconUri_IsAbsolute()
+        {
+            // iconUri is expected to be relative.
+            var absoluteIcon = new Uri("https://example.com/icon.png");
+
+            // Act & Assert
+            Assert.Throws<ArgumentException>(() =>
+                _client.Authorize(new Uri("https://example.com"), absoluteIcon, "TestApp", "mainnet-beta"),
+                "Authorize must throw ArgumentException when iconUri is absolute");
+        }
+
+       
+        // Reauthorize
+        [Test]
+        public void Reauthorize_SendsJsonRpc_WithCorrectMethod()
+        {
+            // Arrange
+            var identityUri = new Uri("https://example.com");
+            const string authToken = "test-auth-token-abc123";
+
+            // Act
+            _ = _client.Reauthorize(identityUri, null, "TestApp", authToken);
+
+            // Assert
+            var request = DecodeLastRequest();
+            Assert.AreEqual("reauthorize", request.Method,
+                "Method must be 'reauthorize'");
+        }
+
+        [Test]
+        public void Reauthorize_SendsJsonRpc_WithAuthToken()
+        {
+            // Arrange
+            var identityUri = new Uri("https://example.com");
+            const string authToken = "test-auth-token-abc123";
+
+            // Act
+            _ = _client.Reauthorize(identityUri, null, "TestApp", authToken);
+
+            // Assert
+            var request = DecodeLastRequest();
+            Assert.AreEqual(authToken, request.Params.AuthToken,
+                "Params.AuthToken must match the supplied auth token");
+        }
+    }
+}

--- a/Tests/EditMode/MwaClient/MobileWalletAdapterClientTests.cs.meta
+++ b/Tests/EditMode/MwaClient/MobileWalletAdapterClientTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 010d7a1ec57f7de47a7a97ba6c2d056d


### PR DESCRIPTION
| Status  | Type  | ⚠️ Core Change | Issue |
| :---: | :---: | :---: | :--: |
| Ready | Tooling | No | Requested by @jonasXchen in MagicBlock Builders Telegram |

> NOTE: This PR adds the first automated test infrastructure to the Solana Unity SDK.
>
> `SolanaMobileWalletAdapter` lifecycle methods are intentionally not covered in this PR because the current constructor throws on non-Android platforms. That work needs a follow-up refactor before those paths can be unit tested cleanly.
>
> Related PRs: #269, #271

## Problem

The Solana Unity SDK did not have any automated test infrastructure before this PR.

That meant core Mobile Wallet Adapter logic had no repeatable regression coverage, including crypto helpers, session state behavior, JSON-RPC request construction, and response model convenience properties. It also made it harder to validate changes requested during recent MWA work without relying entirely on manual testing.

## Solution

This PR adds the first Unity Test Framework scaffold to the SDK and introduces 31 EditMode unit tests across 4 test classes.

The new tests focus on logic that can be exercised in pure EditMode without requiring Android runtime dependencies:

- `EcdsaSignatures` crypto helpers
- `MobileWalletAdapterSession`
- `MobileWalletAdapterClient` JSON-RPC request building
- `Response<T>` computed properties

A `MockMessageSender` test double was added for `IMessageSender` so request payloads can be asserted without a real transport.

This PR is intentionally scoped to the parts of the MWA stack that are already testable in Editor. `SolanaMobileWalletAdapter` lifecycle and reconnect flows are not included yet because they currently depend on constructor behavior that throws on non-Android platforms.

## Before & After Screenshots

_Insert screenshots of example code output_

**BEFORE**:
N/A. No automated tests existed in the SDK before this PR.

**AFTER**:
<img width="849" height="1030" alt="image" src="https://github.com/user-attachments/assets/aef7526c-fe8d-4541-a7ed-605c163e193e" />


## Other changes (e.g. bug fixes, small refactors)

- Added the initial `Tests/` structure for Unity Test Framework coverage
- Added the EditMode test assembly definition and supporting test folder layout
- Added a mock transport helper for request-level unit tests
- Added coverage around MWA crypto and request-building logic that was previously untested
- Added coverage for response model success/failure convenience properties

## Deploy Notes

This PR primarily adds test infrastructure and EditMode unit coverage. It does not introduce new package dependencies or deployment steps.

**New scripts**:

- `Tests/EditMode/Crypto/EcdsaSignaturesTests.cs` : EditMode coverage for DER/P1363 conversion and P-256 key encode/decode
- `Tests/EditMode/Crypto/MobileWalletAdapterSessionTests.cs` : EditMode coverage for session token and pre-ECDH error paths
- `Tests/EditMode/JsonRpc/ResponseModelTests.cs` : EditMode coverage for `Response<T>` success/failure properties
- `Tests/EditMode/MwaClient/MobileWalletAdapterClientTests.cs` : EditMode coverage for JSON-RPC request building
- `Tests/EditMode/Mocks/MockMessageSender.cs` : Test double for `IMessageSender`

**New dependencies**:

- None

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added comprehensive edit-mode test suites for ECDSA signature conversions and key encoding, mobile wallet session behavior and tokens, JSON‑RPC response models, and client request building; included mocking utilities.

* **Bug Fixes**
  * Relaxed an internal assertion related to signature handling and fixed an incorrect decryption error message.

* **Chores**
  * Added test assembly definition and Unity metadata files to support the new tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->