### PR TITLE
feat(MWA): add sign_and_send_transactions

### DIFF
--- a/Runtime/codebase/SolanaMobileStack/Interfaces/IAdapterOperations.cs
+++ b/Runtime/codebase/SolanaMobileStack/Interfaces/IAdapterOperations.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
+using Solana.Unity.SDK;
 using UnityEngine.Scripting;
 
 // ReSharper disable once CheckNamespace
@@ -20,4 +21,6 @@ public interface IAdapterOperations
     public Task<SignedResult> SignTransactions(IEnumerable<byte[]> transactions);
     [Preserve]
     public Task<SignedResult> SignMessages(IEnumerable<byte[]> messages, IEnumerable<byte[]> addresses);
+    [Preserve]
+    public Task<SignAndSendResult> SignAndSendTransactions(IEnumerable<byte[]> transactions, JsonRequest.SignAndSendOptions options);
 }

--- a/Runtime/codebase/SolanaMobileStack/JsonRpcClient/JsonRequest.cs
+++ b/Runtime/codebase/SolanaMobileStack/JsonRpcClient/JsonRequest.cs
@@ -61,8 +61,43 @@ namespace Solana.Unity.SDK
             [RequiredMember]
             public List<string> Addresses { get; set; }
 
+            [JsonProperty("options", NullValueHandling = NullValueHandling.Ignore)]
+            [RequiredMember]
+            public SignAndSendOptions Options { get; set; }
+
             [RequiredMember]
             public JsonRequestParams()
+            {
+            }
+        }
+
+        [Serializable]
+        [Preserve]
+        public class SignAndSendOptions
+        {
+            [JsonProperty("min_context_slot", NullValueHandling = NullValueHandling.Ignore)]
+            [RequiredMember]
+            public int? MinContextSlot { get; set; }
+
+            [JsonProperty("commitment", NullValueHandling = NullValueHandling.Ignore)]
+            [RequiredMember]
+            public string Commitment { get; set; }
+
+            [JsonProperty("skip_preflight", NullValueHandling = NullValueHandling.Ignore)]
+            [RequiredMember]
+            public bool? SkipPreflight { get; set; }
+
+            [JsonProperty("max_retries", NullValueHandling = NullValueHandling.Ignore)]
+            [RequiredMember]
+            public int? MaxRetries { get; set; }
+
+            [JsonProperty("wait_for_commitment_to_send_next_transaction", NullValueHandling = NullValueHandling.Ignore)]
+            [RequiredMember]
+            public bool? WaitForCommitmentToSendNextTransaction { get; set; }
+
+            [Preserve]
+            [RequiredMember]
+            public SignAndSendOptions()
             {
             }
         }

--- a/Runtime/codebase/SolanaMobileStack/JsonRpcClient/JsonRequest.cs
+++ b/Runtime/codebase/SolanaMobileStack/JsonRpcClient/JsonRequest.cs
@@ -77,7 +77,7 @@ namespace Solana.Unity.SDK
         {
             [JsonProperty("min_context_slot", NullValueHandling = NullValueHandling.Ignore)]
             [RequiredMember]
-            public int? MinContextSlot { get; set; }
+            public ulong? MinContextSlot { get; set; }
 
             [JsonProperty("commitment", NullValueHandling = NullValueHandling.Ignore)]
             [RequiredMember]

--- a/Runtime/codebase/SolanaMobileStack/JsonRpcClient/Responses/SignAndSendResult.cs
+++ b/Runtime/codebase/SolanaMobileStack/JsonRpcClient/Responses/SignAndSendResult.cs
@@ -1,0 +1,20 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Newtonsoft.Json;
+using UnityEngine.Scripting;
+
+// ReSharper disable once CheckNamespace
+
+[Preserve]
+public class SignAndSendResult
+{
+    [JsonProperty("signatures")]
+    [RequiredMember]
+    public List<string> Signatures { get; set; }
+
+    [RequiredMember]
+    public List<byte[]> SignaturesBytes => Signatures is { Count: > 0 }
+        ? Signatures.Select(Convert.FromBase64String).ToList()
+        : null;
+}

--- a/Runtime/codebase/SolanaMobileStack/JsonRpcClient/Responses/SignAndSendResult.cs.meta
+++ b/Runtime/codebase/SolanaMobileStack/JsonRpcClient/Responses/SignAndSendResult.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: b8debd5dd1711408a847c6781a83f625

--- a/Runtime/codebase/SolanaMobileStack/MobileWalletAdapterClient.cs
+++ b/Runtime/codebase/SolanaMobileStack/MobileWalletAdapterClient.cs
@@ -71,6 +71,23 @@ public class MobileWalletAdapterClient: JsonRpc20Client, IAdapterOperations, IMe
         return SendRequest<SignedResult>(request);
     }
 
+    public Task<SignAndSendResult> SignAndSendTransactions(IEnumerable<byte[]> transactions, JsonRequest.SignAndSendOptions options)
+    {
+        var request = new JsonRequest
+        {
+            JsonRpc = "2.0",
+            Method = "sign_and_send_transactions",
+            Params = new JsonRequest.JsonRequestParams
+            {
+                Payloads = transactions.Select(Convert.ToBase64String).ToList(),
+                Options = options
+            },
+            Id = NextMessageId()
+        };
+
+        return SendRequest<SignAndSendResult>(request);
+    }
+
     private JsonRequest PrepareAuthRequest(Uri uriIdentity, Uri icon, string name, string cluster, string method)
     {
         if (uriIdentity != null && !uriIdentity.IsAbsoluteUri)

--- a/Runtime/codebase/SolanaMobileStack/SolanaMobileWalletAdapter.cs
+++ b/Runtime/codebase/SolanaMobileStack/SolanaMobileWalletAdapter.cs
@@ -279,7 +279,14 @@ namespace Solana.Unity.SDK
                 Debug.LogError(result.Error.Message);
                 throw new Exception(result.Error.Message);
             }
-            _authToken = authorization.AuthToken;
+            if (authorization == null)
+            {
+                throw new Exception("[MWA] SignAndSend: authorization was not populated");
+            }
+            if (!string.IsNullOrEmpty(authorization.AuthToken))
+            {
+                _authToken = authorization.AuthToken;
+            }
             return res;
         }
 
@@ -302,7 +309,12 @@ namespace Solana.Unity.SDK
             catch (Exception ex)
             {
                 Debug.LogError($"[MWA] sign_and_send: failed to fetch context slot for min_context_slot - {ex.Message}");
-                throw;
+                return new RequestResult<string>
+                {
+                    WasHttpRequestSuccessful = false,
+                    WasRequestSuccessfullyHandled = false,
+                    Reason = $"Failed to fetch context slot for min_context_slot: {ex.Message}"
+                };
             }
 
             var options = new JsonRequest.SignAndSendOptions

--- a/Runtime/codebase/SolanaMobileStack/SolanaMobileWalletAdapter.cs
+++ b/Runtime/codebase/SolanaMobileStack/SolanaMobileWalletAdapter.cs
@@ -2,7 +2,10 @@ using System;
 using System.Linq;
 using System.Collections.Generic;
 using System.Threading.Tasks;
+using Merkator.BitCoin;
+using Solana.Unity.Rpc.Core.Http;
 using Solana.Unity.Rpc.Models;
+using Solana.Unity.Rpc.Types;
 using Solana.Unity.Wallet;
 using UnityEngine;
 using WebSocketSharp;
@@ -236,6 +239,92 @@ namespace Solana.Unity.SDK
             return res.SignedPayloads.Select(transaction => Transaction.Deserialize(transaction)).ToArray();
         }
 
+
+        private async Task<SignAndSendResult> _SignAndSendAllTransactions(
+            Transaction[] transactions, JsonRequest.SignAndSendOptions options)
+        {
+            var cluster = RPCNameMap[(int)RpcCluster];
+            SignAndSendResult res = null;
+            var localAssociationScenario = new LocalAssociationScenario();
+            AuthorizationResult authorization = null;
+            var result = await localAssociationScenario.StartAndExecute(
+                new List<Action<IAdapterOperations>>
+                {
+                    async client =>
+                    {
+                        if (_authToken.IsNullOrEmpty())
+                        {
+                            authorization = await client.Authorize(
+                                new Uri(_walletOptions.identityUri),
+                                new Uri(_walletOptions.iconUri, UriKind.Relative),
+                                _walletOptions.name, cluster);
+                        }
+                        else
+                        {
+                            authorization = await client.Reauthorize(
+                                new Uri(_walletOptions.identityUri),
+                                new Uri(_walletOptions.iconUri, UriKind.Relative),
+                                _walletOptions.name, _authToken);
+                        }
+                    },
+                    async client =>
+                    {
+                        res = await client.SignAndSendTransactions(
+                            transactions.Select(tx => tx.Serialize()).ToList(), options);
+                    }
+                }
+            );
+            if (!result.WasSuccessful)
+            {
+                Debug.LogError(result.Error.Message);
+                throw new Exception(result.Error.Message);
+            }
+            _authToken = authorization.AuthToken;
+            return res;
+        }
+
+        public override async Task<RequestResult<string>> SignAndSendTransaction(
+            Transaction transaction,
+            bool skipPreflight = false,
+            Commitment commitment = Commitment.Confirmed)
+        {
+            transaction.PartialSign(Account);
+            var options = new JsonRequest.SignAndSendOptions
+            {
+                SkipPreflight = skipPreflight,
+                Commitment = commitment.ToString().ToLower()
+            };
+            try
+            {
+                var signAndSendResult = await _SignAndSendAllTransactions(new[] { transaction }, options);
+                if (signAndSendResult?.Signatures == null || signAndSendResult.Signatures.Count == 0)
+                {
+                    return new RequestResult<string>
+                    {
+                        WasHttpRequestSuccessful = true,
+                        WasRequestSuccessfullyHandled = false,
+                        Reason = "Wallet returned no signatures"
+                    };
+                }
+                var sigBase64 = signAndSendResult.Signatures[0];
+                var sigBytes = Convert.FromBase64String(sigBase64);
+                var sigBase58 = Base58Encoding.Encode(sigBytes);
+                return new RequestResult<string>
+                {
+                    WasHttpRequestSuccessful = true,
+                    WasRequestSuccessfullyHandled = true,
+                    Result = sigBase58
+                };
+            }
+            catch (Exception ex)
+            {
+                return new RequestResult<string>
+                {
+                    WasRequestSuccessfullyHandled = false,
+                    Reason = ex.Message
+                };
+            }
+        }
 
         public override void Logout()
         {

--- a/Runtime/codebase/SolanaMobileStack/SolanaMobileWalletAdapter.cs
+++ b/Runtime/codebase/SolanaMobileStack/SolanaMobileWalletAdapter.cs
@@ -289,10 +289,23 @@ namespace Solana.Unity.SDK
             Commitment commitment = Commitment.Confirmed)
         {
             transaction.PartialSign(Account);
+
+            // Fetch context slot for minContextSlot — required by Phantom
+            // (see solana-mobile/mobile-wallet-adapter#1146)
+            ulong? contextSlot = null;
+            try
+            {
+                var blockHash = await ActiveRpcClient.GetLatestBlockHashAsync(commitment);
+                if (blockHash?.Result?.Context?.Slot != null)
+                    contextSlot = blockHash.Result.Context.Slot;
+            }
+            catch (Exception) { /* non-fatal, proceed without it */ }
+
             var options = new JsonRequest.SignAndSendOptions
             {
                 SkipPreflight = skipPreflight,
-                Commitment = commitment.ToString().ToLower()
+                Commitment = commitment.ToString().ToLower(),
+                MinContextSlot = contextSlot
             };
             try
             {

--- a/Runtime/codebase/SolanaMobileStack/SolanaMobileWalletAdapter.cs
+++ b/Runtime/codebase/SolanaMobileStack/SolanaMobileWalletAdapter.cs
@@ -299,7 +299,11 @@ namespace Solana.Unity.SDK
                 if (blockHash?.Result?.Context?.Slot != null)
                     contextSlot = blockHash.Result.Context.Slot;
             }
-            catch (Exception) { /* non-fatal, proceed without it */ }
+            catch (Exception ex)
+            {
+                Debug.LogError($"[MWA] sign_and_send: failed to fetch context slot for min_context_slot - {ex.Message}");
+                throw;
+            }
 
             var options = new JsonRequest.SignAndSendOptions
             {

--- a/Runtime/codebase/SolanaWalletAdapter.cs
+++ b/Runtime/codebase/SolanaWalletAdapter.cs
@@ -1,6 +1,8 @@
 using System;
 using System.Threading.Tasks;
+using Solana.Unity.Rpc.Core.Http;
 using Solana.Unity.Rpc.Models;
+using Solana.Unity.Rpc.Types;
 using Solana.Unity.Wallet;
 
 // ReSharper disable once CheckNamespace
@@ -73,7 +75,17 @@ namespace Solana.Unity.SDK
                 return _internalWallet.SignMessage(message);
             throw new NotImplementedException();
         }
-        
+
+        public override Task<RequestResult<string>> SignAndSendTransaction(
+            Transaction transaction,
+            bool skipPreflight = false,
+            Commitment commitment = Commitment.Confirmed)
+        {
+            if (_internalWallet != null)
+                return _internalWallet.SignAndSendTransaction(transaction, skipPreflight, commitment);
+            throw new NotImplementedException();
+        }
+
         protected override Task<Account> _CreateAccount(string mnemonic = null, string password = null)
         {
             throw new NotImplementedException();


### PR DESCRIPTION
**NOTE:** This PR adds the MWA 2.0 `sign_and_send_transactions` method to the Unity SDK. The wallet signs the transaction and submits it to the network in one step, returning the signature. All tested
   wallets work except Backpack, which crashes due to a deserialization bug on their side.
                                                                                                                                                                                                            
  ## Problem                                                                                                                                                                                                
                                                                                                                                                                                                            
The MWA 2.0 spec defines `sign_and_send_transactions` as a native wallet method that lets the wallet handle both signing and network submission. The Unity SDK only had `sign_transactions`, which meant developers had to sign through the wallet, get the signed transaction back, then submit it themselves via RPC. The React Native SDK already supports `signAndSendTransactions` out of the box.
                                                                                                                                                                                                            
  ## Solution                                               

Added `sign_and_send_transactions` support across the full stack:                                                                                                                                         
   
  - `SignAndSendOptions` class in `JsonRequest.cs` with all spec fields (`min_context_slot`, `commitment`, `skip_preflight`, `max_retries`, `wait_for_commitment_to_send_next_transaction`)                 
  - `SignAndSendResult` response model with base64 signature decoding
  - `SignAndSendTransactions()` on the client and interface                                                                                                                                                 
  - `SignAndSendTransaction()` override on `SolanaMobileWalletAdapter` that opens a session, does auth/reauth, then calls `sign_and_send_transactions`
  - `SignAndSendTransaction()` delegate on `SolanaWalletAdapter`                                                                                                                                            
                                                            
The override automatically fetches `minContextSlot` from the latest blockhash before sending to the wallet. This is needed because Phantom has a known bug  ([solana-mobile/mobile-wallet-adapter#1146](https://github.com/solana-mobile/mobile-wallet-adapter/issues/1146)) where it opens but never shows the approval dialog if `minContextSlot` is not set in the
options. The spec says it's optional, but Phantom requires it. Fetching it automatically means developers don't have to think about it.                                                                   
                                                            
The returned signature is converted from base64 to base58 so it matches what Solana explorers and RPC expect.

## Test Results

Tested on Solana Seeker (Android 15):                                                                                                                                                                     
   
All wallets work except Backpack. **Jupiter**, **Solflare**, **Phantom**, and **Seed Vault** all successfully sign, submit, and return valid base58 transaction signatures.                               
                                                            
**Phantom** originally failed with the same symptom described in issue #1146. It would open the wallet but never show an approval prompt. After adding the automatic `minContextSlot` fetch, Phantom works correctly and shows the approval dialog as expected.     
                                                                                                                                                                                                            
**Backpack** crashes inside its own Kotlin code with `JsonDecodingException: Class discriminator was missing` in `SolanaMobileWalletAdapterWalletLibModule`. This is a Backpack deserialization bug. The transaction payload we send is identical to what Jupiter and Solflare receive and handle fine. There are no open issues or workarounds for this on Backpack's side.
                                                                                                                                                                                                            
## Deploy Notes                                           

No new dependencies. No new scripts. Non-breaking addition. The existing `sign_transactions` path is unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Single-step sign-and-send from wallet adapters with configurable options (commitment level, skip preflight, max retries, wait-for-commitment, context slot) and returned transaction signatures.

* **Behavior Changes**
  * Signing/sending failures surface as non-throwing results containing error details instead of throwing exceptions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->