### PR TITLE
feat(mwa): expose AuthToken on SolanaWalletAdapter  

### DIFF
--- a/Runtime/codebase/SolanaMobileStack/SolanaMobileWalletAdapter.cs
+++ b/Runtime/codebase/SolanaMobileStack/SolanaMobileWalletAdapter.cs
@@ -37,6 +37,8 @@ namespace Solana.Unity.SDK
         private readonly WalletBase _internalWallet;
         private string _authToken;
 
+        public string AuthToken => _authToken;
+
         public event Action OnWalletDisconnected;
         public event Action OnWalletReconnected;
 

--- a/Runtime/codebase/SolanaWalletAdapter.cs
+++ b/Runtime/codebase/SolanaWalletAdapter.cs
@@ -112,6 +112,21 @@ namespace Solana.Unity.SDK
         }
 
         /// <summary>
+        /// The current MWA auth token, or null if unauthorized or the platform
+        /// is not Android. Exposed so callers can persist the token in their
+        /// own auth cache and restore MWA sessions across app launches without
+        /// relying solely on the built-in PlayerPrefs store.
+        /// </summary>
+        public string AuthToken
+        {
+            get
+            {
+                var mobileAdapter = _internalWallet as SolanaMobileWalletAdapter;
+                return mobileAdapter?.AuthToken;
+            }
+        }
+
+        /// <summary>
         /// Queries the connected wallet's supported features and limits.
         /// </summary>
         /// <returns>


### PR DESCRIPTION
⚠️  NOTE: Built on top of #269 which shipped the auth lifecycle overhaul (Deauthorize, GetCapabilities, PlayerPrefs persistence). That PR kept `_authToken` private. This PR adds the read-only getter needed for external auth caches and cross-process session handoff. Pure additions, no behavior change.

     | Status | Type | ⚠️  Core Change | Issue |
     | :---: | :---: | :---: | :---: |
     | Ready | Feature | No | [#273](https://github.com/magicblock-labs/Solana.Unity-SDK/issues/273) |

     ## Problem

After #269, the MWA auth token lifecycle is handled correctly inside `SolanaMobileWalletAdapter` and persisted to PlayerPrefs when `keepConnectionAlive` is on. But the token itself is held in a private `_authToken` field with no public accessor. Every code path that writes to it is internal to the class:

     ```csharp
     // SolanaMobileWalletAdapter.cs on main today
     private string _authToken;

     // ...populated during authorize/reauthorize, written to PlayerPrefs,
     // read back on restore — but never exposed.
     ```

 This closes off a handful of real use cases:

     - **Second-layer auth cache.** Apps that want to encrypt the token at rest, or sync it to a keychain/keystore, can't read it from the adapter to re-persist.
     - **Native + Unity session sharing.** Hybrid apps (native Android shell hosting a Unity module) need to pass the token between layers. Today the Unity side has no way to hand it off.
     - **Server-side receipt.** Game servers that want a signed capability proof with the session token in the body have no access point.
     - **Debugging and diagnostics.** Support flows ("paste your current session id") need to read the token without depending on PlayerPrefs key names, which are implementation details.

The only workaround today is reading the PlayerPrefs key directly (`solana_sdk.mwa.auth_token`), which couples callers to the SDK's storage schema and breaks the moment the SDK changes key names or adds encryption.

     ## Solution

 Adds a read-only `AuthToken` property in two places, following the same delegation pattern as `GetCapabilities`, `DisconnectWallet`, and `ReconnectWallet`.

     **`SolanaMobileWalletAdapter.cs`** — the actual adapter that owns `_authToken`:

     ```csharp
     private string _authToken;

     public string AuthToken => _authToken;
     ```

     **`SolanaWalletAdapter.cs`** — the cross-platform wrapper apps actually hold:

     ```csharp
     public string AuthToken
     {
         get
         {
             var mobileAdapter = _internalWallet as SolanaMobileWalletAdapter;
             return mobileAdapter?.AuthToken;
         }
     }
     ```

Returns `null` when `_internalWallet` is null, when the platform isn't Android, or when authorize hasn't completed yet. Non-null once the MWA session is live. No setter. Callers can observe but not overwrite.

     ## Before & After

     **BEFORE** - no access point, callers have to reach into PlayerPrefs directly:

     ```csharp
     var account = await Web3.Instance.LoginWalletAdapter();
     // account.PublicKey is available, but the auth token the SDK just
     // received from the wallet is unreachable from here.

     // Only workaround: hit PlayerPrefs and depend on the SDK's key name.
     var token = PlayerPrefs.GetString("solana_sdk.mwa.auth_token");
     // Breaks silently if the SDK ever renames or encrypts this key.
     ```

     **AFTER** - first-class read, no coupling to storage internals:

     ```csharp
     var account = await Web3.Instance.LoginWalletAdapter();
     var walletAdapter = Web3.Instance.Wallet as SolanaWalletAdapter;
     var token = walletAdapter?.AuthToken;

     // Encrypt and store in our own cache.
     await MyAuthCache.PutAsync(account.PublicKey, token);

     // Or pass to a native bridge.
     AndroidBridge.SetSessionToken(token);
     ```

Returns `null` cleanly on WebGL, iOS, pre-login, and post-logout — callers can null-check and skip the cache write without a try/catch.

     ## Other changes (e.g. bug fixes, small refactors)

     None. Two property additions, no refactors, no behavior changes elsewhere.

     ## Deploy Notes

No new dependencies. No new scripts. No configuration changes. Non-breaking — `AuthToken` is a pure addition; existing consumers are unaffected. PlayerPrefs persistence from #269 continues to work exactly as before.

     **New scripts**: none
     **New dependencies**: none