### PR TITLE
Feat(test)/mwa keep connection alive tests

### DIFF
--- a/Tests/EditMode/Contracts.meta
+++ b/Tests/EditMode/Contracts.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: a8a57d97f35a28348914ed9a7b2288b5
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Tests/EditMode/Contracts/IAdapterOperationsContractTests.cs
+++ b/Tests/EditMode/Contracts/IAdapterOperationsContractTests.cs
@@ -1,0 +1,188 @@
+using NUnit.Framework;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Threading.Tasks;
+using UnityEngine.Scripting;
+
+// ReSharper disable once CheckNamespace
+namespace Solana.Unity.SDK.Tests.EditMode.Contracts
+{
+    /// <summary>
+    /// Compile-time / reflection contract tests for <see cref="IAdapterOperations"/>.
+    /// These exist because the interface is the stable boundary between the
+    /// SDK and every wallet transport that implements it. A silent signature
+    /// drift here would break implementers without any compile error on our
+    /// side until runtime, so we pin shape, parameter types, return types,
+    /// and the <see cref="PreserveAttribute"/> (needed so IL2CPP / Unity
+    /// managed stripping cannot remove these members in AOT builds).
+    /// </summary>
+    [Category("Lifecycle")]
+    public class IAdapterOperationsContractTests
+    {
+        private static MethodInfo GetMethod(string name)
+        {
+            return typeof(IAdapterOperations)
+                .GetMethod(name, BindingFlags.Instance | BindingFlags.Public);
+        }
+
+        private static bool HasParams(MethodInfo m, params Type[] expected)
+        {
+            var actual = m.GetParameters().Select(p => p.ParameterType).ToArray();
+            if (actual.Length != expected.Length) return false;
+            for (int i = 0; i < actual.Length; i++)
+                if (actual[i] != expected[i]) return false;
+            return true;
+        }
+
+        
+        // Authorize
+        [Test]
+        public void Interface_Has_Authorize_WithExpectedSignature()
+        {
+            var method = GetMethod(nameof(IAdapterOperations.Authorize));
+
+            Assert.IsNotNull(method, "IAdapterOperations.Authorize must exist");
+            Assert.AreEqual(typeof(Task<AuthorizationResult>), method.ReturnType,
+                "Authorize must return Task<AuthorizationResult>");
+            Assert.IsTrue(HasParams(method, typeof(Uri), typeof(Uri), typeof(string), typeof(string)),
+                "Authorize params must be (Uri identityUri, Uri iconUri, string identityName, string rpcCluster)");
+        }
+
+        
+        // Reauthorize
+        [Test]
+        public void Interface_Has_Reauthorize_WithExpectedSignature()
+        {
+            var method = GetMethod(nameof(IAdapterOperations.Reauthorize));
+
+            Assert.IsNotNull(method, "IAdapterOperations.Reauthorize must exist");
+            Assert.AreEqual(typeof(Task<AuthorizationResult>), method.ReturnType,
+                "Reauthorize must return Task<AuthorizationResult>");
+            Assert.IsTrue(HasParams(method, typeof(Uri), typeof(Uri), typeof(string), typeof(string)),
+                "Reauthorize params must be (Uri identityUri, Uri iconUri, string identityName, string authToken)");
+        }
+
+        
+        // Deauthorize
+        [Test]
+        public void Interface_Has_Deauthorize_AcceptingStringAuthToken()
+        {
+            var method = GetMethod(nameof(IAdapterOperations.Deauthorize));
+
+            Assert.IsNotNull(method, "IAdapterOperations.Deauthorize must exist");
+            Assert.IsTrue(HasParams(method, typeof(string)),
+                "Deauthorize must accept exactly (string authToken)");
+        }
+
+        [Test]
+        public void Deauthorize_ReturnType_IsNonGenericTask()
+        {
+            var method = GetMethod(nameof(IAdapterOperations.Deauthorize));
+
+            Assert.IsNotNull(method);
+            Assert.AreEqual(typeof(Task), method.ReturnType,
+                "Deauthorize must return non-generic Task (fire-and-forget result)");
+            Assert.IsFalse(method.ReturnType.IsGenericType,
+                "Deauthorize return type must not be generic");
+        }
+
+        
+        // GetCapabilities
+        [Test]
+        public void Interface_Has_GetCapabilities_WithNoParameters()
+        {
+            var method = GetMethod(nameof(IAdapterOperations.GetCapabilities));
+
+            Assert.IsNotNull(method, "IAdapterOperations.GetCapabilities must exist");
+            Assert.AreEqual(0, method.GetParameters().Length,
+                "GetCapabilities must take no parameters");
+        }
+
+        [Test]
+        public void GetCapabilities_ReturnType_IsTaskOfCapabilitiesResult()
+        {
+            var method = GetMethod(nameof(IAdapterOperations.GetCapabilities));
+
+            Assert.IsNotNull(method);
+            Assert.AreEqual(typeof(Task<CapabilitiesResult>), method.ReturnType,
+                "GetCapabilities must return Task<CapabilitiesResult>");
+        }
+
+        
+        // Sign operations, signatures unchanged but guarded against regression
+        [Test]
+        public void Interface_Has_SignTransactions_WithExpectedSignature()
+        {
+            var method = GetMethod(nameof(IAdapterOperations.SignTransactions));
+
+            Assert.IsNotNull(method);
+            Assert.AreEqual(typeof(Task<SignedResult>), method.ReturnType,
+                "SignTransactions must return Task<SignedResult>");
+            Assert.IsTrue(HasParams(method, typeof(IEnumerable<byte[]>)),
+                "SignTransactions params must be (IEnumerable<byte[]> transactions)");
+        }
+
+        [Test]
+        public void Interface_Has_SignMessages_WithExpectedSignature()
+        {
+            var method = GetMethod(nameof(IAdapterOperations.SignMessages));
+
+            Assert.IsNotNull(method);
+            Assert.AreEqual(typeof(Task<SignedResult>), method.ReturnType,
+                "SignMessages must return Task<SignedResult>");
+            Assert.IsTrue(HasParams(method, typeof(IEnumerable<byte[]>), typeof(IEnumerable<byte[]>)),
+                "SignMessages params must be (IEnumerable<byte[]> messages, IEnumerable<byte[]> addresses)");
+        }
+
+        
+        // [Preserve] attribute coverage, required for IL2CPP / managed stripping
+        [Test]
+        public void AllInterfaceMethods_Have_PreserveAttribute()
+        {
+            var methods = typeof(IAdapterOperations)
+                .GetMethods(BindingFlags.Instance | BindingFlags.Public);
+
+            Assert.Greater(methods.Length, 0, "Interface must expose at least one method");
+            foreach (var method in methods)
+            {
+                var preserve = method.GetCustomAttribute<PreserveAttribute>();
+                Assert.IsNotNull(preserve,
+                    $"{method.Name} must carry [Preserve] so IL2CPP does not strip it in AOT builds");
+            }
+        }
+
+        [Test]
+        public void Interface_Itself_HasPreserveAttribute()
+        {
+            var preserve = typeof(IAdapterOperations).GetCustomAttribute<PreserveAttribute>();
+            Assert.IsNotNull(preserve,
+                "IAdapterOperations type must carry [Preserve]");
+        }
+
+        
+        // Implementation sanity
+        [Test]
+        public void MobileWalletAdapterClient_Implements_IAdapterOperations()
+        {
+            // Cheap sanity check: the production implementer must still
+            // satisfy the interface after any refactor.
+            Assert.IsTrue(typeof(IAdapterOperations).IsAssignableFrom(typeof(MobileWalletAdapterClient)),
+                "MobileWalletAdapterClient must implement IAdapterOperations");
+        }
+
+        [Test]
+        public void InterfaceMethodCount_MatchesExpectedSurface()
+        {
+            // Deauthorize, GetCapabilities, SignTransactions, SignMessages.
+            // If this number changes, the contract tests above must be
+            // updated to cover any new members.
+            var methods = typeof(IAdapterOperations)
+                .GetMethods(BindingFlags.Instance | BindingFlags.Public);
+
+            Assert.AreEqual(6, methods.Length,
+                "IAdapterOperations must expose exactly 6 methods; update contract tests when this changes");
+        }
+    }
+}

--- a/Tests/EditMode/Contracts/IAdapterOperationsContractTests.cs.meta
+++ b/Tests/EditMode/Contracts/IAdapterOperationsContractTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: f69b6c01b93377048b0db3e4e6bd27fb

--- a/Tests/EditMode/JsonRpc/CapabilitiesResultTests.cs
+++ b/Tests/EditMode/JsonRpc/CapabilitiesResultTests.cs
@@ -1,0 +1,214 @@
+using NUnit.Framework;
+using Newtonsoft.Json;
+
+// ReSharper disable once CheckNamespace
+namespace Solana.Unity.SDK.Tests.EditMode.JsonRpc
+{
+    /// <summary>
+    /// Edit mode tests for <see cref="CapabilitiesResult"/> wire format.
+    /// The MWA spec dictates the snake_case JSON property names, and these
+    /// tests pin them so a rename on the C# side cannot silently break the
+    /// deserializer. Every numeric and version field is also nullable so
+    /// absence is represented as null, never a default value.
+    /// </summary>
+    [Category("Lifecycle")]
+    public class CapabilitiesResultTests
+    {
+        
+        // Snake_case property names
+        [Test]
+        public void Deserialize_MaxTransactionsPerRequest_FromSnakeCaseJson()
+        {
+            // Arrange
+            const string json = "{\"max_transactions_per_request\":10}";
+
+            // Act
+            var result = JsonConvert.DeserializeObject<CapabilitiesResult>(json);
+
+            // Assert
+            Assert.IsNotNull(result);
+            Assert.AreEqual(10, result.MaxTransactionsPerRequest,
+                "max_transactions_per_request must deserialize to MaxTransactionsPerRequest");
+        }
+
+        [Test]
+        public void Deserialize_MaxMessagesPerRequest_FromSnakeCaseJson()
+        {
+            // Arrange
+            const string json = "{\"max_messages_per_request\":5}";
+
+            // Act
+            var result = JsonConvert.DeserializeObject<CapabilitiesResult>(json);
+
+            // Assert
+            Assert.AreEqual(5, result.MaxMessagesPerRequest,
+                "max_messages_per_request must deserialize to MaxMessagesPerRequest");
+        }
+
+        [Test]
+        public void Deserialize_SupportedTransactionVersions_AsStringArray()
+        {
+            // Arrange
+            const string json = "{\"supported_transaction_versions\":[\"legacy\",\"0\"]}";
+
+            // Act
+            var result = JsonConvert.DeserializeObject<CapabilitiesResult>(json);
+
+            // Assert
+            Assert.IsNotNull(result.SupportedTransactionVersions,
+                "SupportedTransactionVersions must not be null when JSON array is present");
+            Assert.AreEqual(2, result.SupportedTransactionVersions.Length);
+            Assert.AreEqual("legacy", result.SupportedTransactionVersions[0]);
+            Assert.AreEqual("0", result.SupportedTransactionVersions[1]);
+        }
+
+        [Test]
+        public void Deserialize_SupportsCloneAuthorization_True()
+        {
+            // Arrange
+            const string json = "{\"supports_clone_authorization\":true}";
+
+            // Act
+            var result = JsonConvert.DeserializeObject<CapabilitiesResult>(json);
+
+            // Assert
+            Assert.IsTrue(result.SupportsCloneAuthorization.HasValue);
+            Assert.IsTrue(result.SupportsCloneAuthorization.Value,
+                "supports_clone_authorization:true must deserialize to true");
+        }
+
+        [Test]
+        public void Deserialize_SupportsCloneAuthorization_False()
+        {
+            // Arrange
+            const string json = "{\"supports_clone_authorization\":false}";
+
+            // Act
+            var result = JsonConvert.DeserializeObject<CapabilitiesResult>(json);
+
+            // Assert
+            Assert.IsTrue(result.SupportsCloneAuthorization.HasValue);
+            Assert.IsFalse(result.SupportsCloneAuthorization.Value,
+                "supports_clone_authorization:false must deserialize to false");
+        }
+
+        
+        // Absence handling
+        [Test]
+        public void AllNullableFields_AreNull_WhenAbsentFromJson()
+        {
+            // Arrange
+            // supports_clone_authorization is bool? so absence must stay null,
+            // not implicitly coerce to false.
+            const string json = "{}";
+
+            // Act
+            var result = JsonConvert.DeserializeObject<CapabilitiesResult>(json);
+
+            // Assert
+            Assert.IsNotNull(result, "Empty object must still deserialize to a non-null instance");
+            Assert.IsNull(result.MaxTransactionsPerRequest,
+                "MaxTransactionsPerRequest must be null when absent");
+            Assert.IsNull(result.MaxMessagesPerRequest,
+                "MaxMessagesPerRequest must be null when absent");
+            Assert.IsNull(result.SupportedTransactionVersions,
+                "SupportedTransactionVersions must be null when absent");
+            Assert.IsNull(result.SupportsCloneAuthorization,
+                "SupportsCloneAuthorization is bool? and must be null (not false) when absent");
+        }
+
+        [Test]
+        public void EmptyJsonObject_Deserializes_WithoutException()
+        {
+            const string json = "{}";
+
+            Assert.DoesNotThrow(() => JsonConvert.DeserializeObject<CapabilitiesResult>(json),
+                "Empty object must not throw during deserialization");
+        }
+
+        [Test]
+        public void UnknownJsonFields_AreIgnored_NoException()
+        {
+            // Forward compatibility: the MWA spec may add new fields that the
+            // SDK does not yet know about. Deserialization must tolerate them.
+            const string json = "{\"max_transactions_per_request\":3," +
+                                "\"future_field_not_yet_modeled\":\"unknown\"," +
+                                "\"another_unknown\":42}";
+
+            CapabilitiesResult result = null;
+            Assert.DoesNotThrow(() => result = JsonConvert.DeserializeObject<CapabilitiesResult>(json),
+                "Unknown fields must be silently ignored by the deserializer");
+            Assert.IsNotNull(result);
+            Assert.AreEqual(3, result.MaxTransactionsPerRequest,
+                "Known fields must still deserialize when unknown fields are present");
+        }
+
+        
+        // Full payload round trip
+        [Test]
+        public void FullPayload_Deserializes_AllFields()
+        {
+            // Arrange
+            const string json = "{" +
+                                "\"supports_clone_authorization\":true," +
+                                "\"max_transactions_per_request\":12," +
+                                "\"max_messages_per_request\":7," +
+                                "\"supported_transaction_versions\":[\"legacy\",\"0\"]" +
+                                "}";
+
+            // Act
+            var result = JsonConvert.DeserializeObject<CapabilitiesResult>(json);
+
+            // Assert
+            Assert.IsNotNull(result);
+            Assert.AreEqual(true, result.SupportsCloneAuthorization);
+            Assert.AreEqual(12, result.MaxTransactionsPerRequest);
+            Assert.AreEqual(7, result.MaxMessagesPerRequest);
+            Assert.IsNotNull(result.SupportedTransactionVersions);
+            Assert.AreEqual(2, result.SupportedTransactionVersions.Length);
+        }
+
+        
+        // Response<CapabilitiesResult> wrapper - wire-level success/failure
+        [Test]
+        public void InsideResponseWrapper_WasSuccessful_TrueWhenErrorNull()
+        {
+            // CapabilitiesResult itself has no error flag, but the generic
+            // Response<T> envelope does. Pin that Response<CapabilitiesResult>
+            // composes correctly so callers can keep using WasSuccessful.
+            var response = new Response<CapabilitiesResult>
+            {
+                JsonRpc = "2.0",
+                Id = 1,
+                Result = new CapabilitiesResult { MaxTransactionsPerRequest = 4 },
+                Error = null
+            };
+
+            Assert.IsTrue(response.WasSuccessful,
+                "Response<CapabilitiesResult>.WasSuccessful must be true when Error is null");
+            Assert.IsFalse(response.Failed);
+            Assert.IsNotNull(response.Result);
+            Assert.AreEqual(4, response.Result.MaxTransactionsPerRequest);
+        }
+
+        [Test]
+        public void InsideResponseWrapper_Failed_TrueWhenErrorPresent()
+        {
+            var response = new Response<CapabilitiesResult>
+            {
+                JsonRpc = "2.0",
+                Id = 1,
+                Result = null,
+                Error = new Response<CapabilitiesResult>.ResponseError
+                {
+                    Code = -32601,
+                    Message = "Method not found"
+                }
+            };
+
+            Assert.IsTrue(response.Failed,
+                "Response<CapabilitiesResult>.Failed must be true when Error is set");
+            Assert.IsFalse(response.WasSuccessful);
+        }
+    }
+}

--- a/Tests/EditMode/JsonRpc/CapabilitiesResultTests.cs.meta
+++ b/Tests/EditMode/JsonRpc/CapabilitiesResultTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 882afb73ca7111043b7b44dcff4808bd

--- a/Tests/EditMode/Lifecycle.meta
+++ b/Tests/EditMode/Lifecycle.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 201461c93fb2d074fa7476705d0519d4
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Tests/EditMode/Lifecycle/SolanaMobileWalletAdapterPrefsTests.cs
+++ b/Tests/EditMode/Lifecycle/SolanaMobileWalletAdapterPrefsTests.cs
@@ -1,0 +1,212 @@
+using NUnit.Framework;
+using System.Reflection;
+using UnityEngine;
+
+// ReSharper disable once CheckNamespace
+namespace Solana.Unity.SDK.Tests.EditMode.Lifecycle
+{
+    /// <summary>
+    /// Edit mode tests for <see cref="SolanaMobileWalletAdapter"/> PlayerPrefs
+    /// behavior introduced in PR #269.
+    ///
+    /// The adapter constructor throws on non-Android platforms, so we cannot
+    /// instantiate the class in the Editor. Instead we use reflection to:
+    ///   1. Pin the new namespaced key constants (PrefKeyPublicKey /
+    ///      PrefKeyAuthToken) so a rename is caught immediately.
+    ///   2. Invoke the private static <c>MigrateLegacyPrefKeys</c> method
+    ///      and assert legacy <c>"pk"</c> / <c>"authToken"</c> entries move
+    ///      to the namespaced keys exactly once without overwriting newer
+    ///      data.
+    ///
+    /// [TearDown] wipes every key the test might have touched so PlayerPrefs
+    /// (which persists in the registry under the Unity editor project) stays
+    /// clean between runs.
+    /// </summary>
+    [Category("Lifecycle")]
+    public class SolanaMobileWalletAdapterPrefsTests
+    {
+        private const string LegacyPk = "pk";
+        private const string LegacyAuthToken = "authToken";
+        private const string NewPkKey = "solana_sdk.mwa.public_key";
+        private const string NewAuthTokenKey = "solana_sdk.mwa.auth_token";
+
+        [SetUp]
+        public void SetUp()
+        {
+            DeleteAllRelevantKeys();
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            DeleteAllRelevantKeys();
+        }
+
+        private static void DeleteAllRelevantKeys()
+        {
+            PlayerPrefs.DeleteKey(LegacyPk);
+            PlayerPrefs.DeleteKey(LegacyAuthToken);
+            PlayerPrefs.DeleteKey(NewPkKey);
+            PlayerPrefs.DeleteKey(NewAuthTokenKey);
+            PlayerPrefs.Save();
+        }
+
+        private static void InvokeMigrate()
+        {
+            // MigrateLegacyPrefKeys is private static; reflection is the only
+            // way to exercise it without instantiating the adapter (which
+            // fails on non-Android editors).
+            var method = typeof(SolanaMobileWalletAdapter)
+                .GetMethod("MigrateLegacyPrefKeys",
+                    BindingFlags.Static | BindingFlags.NonPublic);
+            Assert.IsNotNull(method,
+                "Private static MigrateLegacyPrefKeys must exist on SolanaMobileWalletAdapter");
+            method.Invoke(null, null);
+        }
+
+        private static string GetPrivateConst(string name)
+        {
+            var field = typeof(SolanaMobileWalletAdapter)
+                .GetField(name, BindingFlags.Static | BindingFlags.NonPublic);
+            Assert.IsNotNull(field, $"Private const {name} must exist");
+            return (string)field.GetRawConstantValue();
+        }
+
+        
+        // Pin the namespaced key values
+        [Test]
+        public void PrefKeyConstants_HaveNamespacedValues()
+        {
+            // These exact strings form the cross-version migration contract.
+            // Changing them breaks existing installs that persisted the old
+            // legacy keys through the migration step in the ctor.
+            Assert.AreEqual(NewPkKey, GetPrivateConst("PrefKeyPublicKey"),
+                "PrefKeyPublicKey must stay 'solana_sdk.mwa.public_key'");
+            Assert.AreEqual(NewAuthTokenKey, GetPrivateConst("PrefKeyAuthToken"),
+                "PrefKeyAuthToken must stay 'solana_sdk.mwa.auth_token'");
+        }
+
+        
+        // Migration behavior
+        [Test]
+        public void MigrateLegacyPrefKeys_NoLegacyKeys_IsNoOp()
+        {
+            // Nothing in PlayerPrefs at start.
+            InvokeMigrate();
+
+            Assert.IsFalse(PlayerPrefs.HasKey(LegacyPk));
+            Assert.IsFalse(PlayerPrefs.HasKey(LegacyAuthToken));
+            Assert.IsFalse(PlayerPrefs.HasKey(NewPkKey),
+                "Migration must not invent data when nothing is stored");
+            Assert.IsFalse(PlayerPrefs.HasKey(NewAuthTokenKey),
+                "Migration must not invent data when nothing is stored");
+        }
+
+        [Test]
+        public void MigrateLegacyPrefKeys_Migrates_LegacyPk_ToNewKey()
+        {
+            // Arrange
+            PlayerPrefs.SetString(LegacyPk, "pubkey-abc");
+            PlayerPrefs.Save();
+
+            // Act
+            InvokeMigrate();
+
+            // Assert
+            Assert.IsTrue(PlayerPrefs.HasKey(NewPkKey),
+                "Legacy 'pk' must be copied to the namespaced key");
+            Assert.AreEqual("pubkey-abc", PlayerPrefs.GetString(NewPkKey),
+                "Namespaced key must carry the legacy value");
+        }
+
+        [Test]
+        public void MigrateLegacyPrefKeys_Migrates_LegacyAuthToken_ToNewKey()
+        {
+            // Arrange
+            PlayerPrefs.SetString(LegacyAuthToken, "token-xyz-123");
+            PlayerPrefs.Save();
+
+            // Act
+            InvokeMigrate();
+
+            // Assert
+            Assert.IsTrue(PlayerPrefs.HasKey(NewAuthTokenKey),
+                "Legacy 'authToken' must be copied to the namespaced key");
+            Assert.AreEqual("token-xyz-123", PlayerPrefs.GetString(NewAuthTokenKey));
+        }
+
+        [Test]
+        public void MigrateLegacyPrefKeys_Deletes_LegacyKeys_AfterMigration()
+        {
+            // Arrange
+            PlayerPrefs.SetString(LegacyPk, "pubkey-abc");
+            PlayerPrefs.SetString(LegacyAuthToken, "token-xyz-123");
+            PlayerPrefs.Save();
+
+            // Act
+            InvokeMigrate();
+
+            // Assert - legacy keys must be gone so a subsequent call is a no-op.
+            Assert.IsFalse(PlayerPrefs.HasKey(LegacyPk),
+                "Legacy 'pk' key must be deleted after migration");
+            Assert.IsFalse(PlayerPrefs.HasKey(LegacyAuthToken),
+                "Legacy 'authToken' key must be deleted after migration");
+        }
+
+        [Test]
+        public void MigrateLegacyPrefKeys_DoesNotOverwrite_WhenNewKeyAlreadySet()
+        {
+            // If a newer session has already produced namespaced values,
+            // the migration must not clobber them with stale legacy data.
+            PlayerPrefs.SetString(LegacyPk, "legacy-pubkey");
+            PlayerPrefs.SetString(NewPkKey, "new-pubkey");
+            PlayerPrefs.SetString(LegacyAuthToken, "legacy-token");
+            PlayerPrefs.SetString(NewAuthTokenKey, "new-token");
+            PlayerPrefs.Save();
+
+            // Act
+            InvokeMigrate();
+
+            // Assert
+            Assert.AreEqual("new-pubkey", PlayerPrefs.GetString(NewPkKey),
+                "Existing namespaced pubkey must not be overwritten");
+            Assert.AreEqual("new-token", PlayerPrefs.GetString(NewAuthTokenKey),
+                "Existing namespaced auth token must not be overwritten");
+            Assert.IsFalse(PlayerPrefs.HasKey(LegacyPk),
+                "Legacy 'pk' key must still be deleted even when skipped");
+            Assert.IsFalse(PlayerPrefs.HasKey(LegacyAuthToken),
+                "Legacy 'authToken' key must still be deleted even when skipped");
+        }
+
+        [Test]
+        public void MigrateLegacyPrefKeys_SecondCall_IsNoOp()
+        {
+            // Idempotence: calling migrate twice in a row (e.g. two adapter
+            // instances in the same session) must not corrupt data.
+            PlayerPrefs.SetString(LegacyPk, "pubkey-abc");
+            PlayerPrefs.Save();
+
+            InvokeMigrate();
+            InvokeMigrate();
+
+            Assert.IsTrue(PlayerPrefs.HasKey(NewPkKey));
+            Assert.AreEqual("pubkey-abc", PlayerPrefs.GetString(NewPkKey));
+            Assert.IsFalse(PlayerPrefs.HasKey(LegacyPk));
+        }
+
+        [Test]
+        public void MigrateLegacyPrefKeys_OnlyAuthTokenPresent_Migrates()
+        {
+            // Half-migrated installs must still converge.
+            PlayerPrefs.SetString(LegacyAuthToken, "only-token");
+            PlayerPrefs.Save();
+
+            InvokeMigrate();
+
+            Assert.AreEqual("only-token", PlayerPrefs.GetString(NewAuthTokenKey));
+            Assert.IsFalse(PlayerPrefs.HasKey(NewPkKey),
+                "Pubkey namespaced key must not be fabricated when only auth token was legacy");
+            Assert.IsFalse(PlayerPrefs.HasKey(LegacyAuthToken));
+        }
+    }
+}

--- a/Tests/EditMode/Lifecycle/SolanaMobileWalletAdapterPrefsTests.cs
+++ b/Tests/EditMode/Lifecycle/SolanaMobileWalletAdapterPrefsTests.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using NUnit.Framework;
 using System.Reflection;
 using UnityEngine;
@@ -18,9 +19,8 @@ namespace Solana.Unity.SDK.Tests.EditMode.Lifecycle
     ///      to the namespaced keys exactly once without overwriting newer
     ///      data.
     ///
-    /// [TearDown] wipes every key the test might have touched so PlayerPrefs
-    /// (which persists in the registry under the Unity editor project) stays
-    /// clean between runs.
+    /// [SetUp]/[TearDown] snapshot and restore any pre-existing values because
+    /// EditMode PlayerPrefs persist in the Unity editor project between runs.
     /// </summary>
     [Category("Lifecycle")]
     public class SolanaMobileWalletAdapterPrefsTests
@@ -29,10 +29,20 @@ namespace Solana.Unity.SDK.Tests.EditMode.Lifecycle
         private const string LegacyAuthToken = "authToken";
         private const string NewPkKey = "solana_sdk.mwa.public_key";
         private const string NewAuthTokenKey = "solana_sdk.mwa.auth_token";
+        private static readonly string[] RelevantKeys =
+        {
+            LegacyPk,
+            LegacyAuthToken,
+            NewPkKey,
+            NewAuthTokenKey
+        };
+
+        private Dictionary<string, string> _originalPrefs;
 
         [SetUp]
         public void SetUp()
         {
+            _originalPrefs = SnapshotRelevantKeys();
             DeleteAllRelevantKeys();
         }
 
@@ -40,14 +50,45 @@ namespace Solana.Unity.SDK.Tests.EditMode.Lifecycle
         public void TearDown()
         {
             DeleteAllRelevantKeys();
+            RestoreOriginalKeys();
+        }
+
+        private static Dictionary<string, string> SnapshotRelevantKeys()
+        {
+            var snapshot = new Dictionary<string, string>();
+            foreach (var key in RelevantKeys)
+            {
+                if (PlayerPrefs.HasKey(key))
+                {
+                    snapshot[key] = PlayerPrefs.GetString(key);
+                }
+            }
+
+            return snapshot;
+        }
+
+        private void RestoreOriginalKeys()
+        {
+            if (_originalPrefs == null)
+            {
+                return;
+            }
+
+            foreach (var entry in _originalPrefs)
+            {
+                PlayerPrefs.SetString(entry.Key, entry.Value);
+            }
+
+            PlayerPrefs.Save();
         }
 
         private static void DeleteAllRelevantKeys()
         {
-            PlayerPrefs.DeleteKey(LegacyPk);
-            PlayerPrefs.DeleteKey(LegacyAuthToken);
-            PlayerPrefs.DeleteKey(NewPkKey);
-            PlayerPrefs.DeleteKey(NewAuthTokenKey);
+            foreach (var key in RelevantKeys)
+            {
+                PlayerPrefs.DeleteKey(key);
+            }
+
             PlayerPrefs.Save();
         }
 

--- a/Tests/EditMode/Lifecycle/SolanaMobileWalletAdapterPrefsTests.cs.meta
+++ b/Tests/EditMode/Lifecycle/SolanaMobileWalletAdapterPrefsTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 9b0a5c5d35df35c42bd99498c85f7771

--- a/Tests/EditMode/MwaClient/MobileWalletAdapterClientLifecycleTests.cs
+++ b/Tests/EditMode/MwaClient/MobileWalletAdapterClientLifecycleTests.cs
@@ -2,7 +2,7 @@ using NUnit.Framework;
 using System.Reflection;
 using System.Text;
 using System.Threading.Tasks;
-using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
 using Solana.Unity.SDK.Tests.EditMode.Mocks;
 
 // ReSharper disable once CheckNamespace
@@ -32,20 +32,43 @@ namespace Solana.Unity.SDK.Tests.EditMode.MwaClient
         // Helpers
 
         /// <summary>
-        /// Reads the last captured message and decodes it as JsonRequest.
-        /// Mirrors the helper in MobileWalletAdapterClientTests.cs.
+        /// Reads the last captured message as raw JSON so the tests assert the
+        /// actual wire format rather than a round-trip through JsonRequest.
         /// </summary>
-        private JsonRequest DecodeLastRequest()
+        private JObject DecodeLastRequestObject()
         {
             Assert.IsNotNull(_sender.LastMessage, "No message was sent to MockMessageSender");
             var json = Encoding.UTF8.GetString(_sender.LastMessage);
-            return JsonConvert.DeserializeObject<JsonRequest>(json);
+            return JObject.Parse(json);
         }
 
-        private JsonRequest DecodeRequestAt(int index)
+        private JObject DecodeRequestObjectAt(int index)
         {
             var json = Encoding.UTF8.GetString(_sender.SentMessages[index]);
-            return JsonConvert.DeserializeObject<JsonRequest>(json);
+            return JObject.Parse(json);
+        }
+
+        private JObject DecodeLastParamsObject()
+        {
+            return GetParamsObject(DecodeLastRequestObject());
+        }
+
+        private static JObject GetParamsObject(JObject request)
+        {
+            var paramsToken = request["params"];
+            Assert.IsNotNull(paramsToken, "Request must include a params object");
+            Assert.AreEqual(JTokenType.Object, paramsToken.Type,
+                "Request params must serialize as a JSON object");
+            return (JObject)paramsToken;
+        }
+
+        private static int GetRequestId(JObject request)
+        {
+            var idToken = request["id"];
+            Assert.IsNotNull(idToken, "Request must include an id");
+            Assert.AreEqual(JTokenType.Integer, idToken.Type,
+                "Request id must serialize as a JSON integer");
+            return idToken.Value<int>();
         }
 
         
@@ -57,8 +80,8 @@ namespace Solana.Unity.SDK.Tests.EditMode.MwaClient
             _ = _client.Deauthorize("test-auth-token-abc123");
 
             // Assert
-            var request = DecodeLastRequest();
-            Assert.AreEqual("deauthorize", request.Method,
+            var request = DecodeLastRequestObject();
+            Assert.AreEqual("deauthorize", request.Value<string>("method"),
                 "Method must be 'deauthorize'");
         }
 
@@ -67,8 +90,8 @@ namespace Solana.Unity.SDK.Tests.EditMode.MwaClient
         {
             _ = _client.Deauthorize("test-auth-token-abc123");
 
-            var request = DecodeLastRequest();
-            Assert.AreEqual("2.0", request.JsonRpc,
+            var request = DecodeLastRequestObject();
+            Assert.AreEqual("2.0", request.Value<string>("jsonrpc"),
                 "JsonRpc version must be '2.0'");
         }
 
@@ -82,10 +105,9 @@ namespace Solana.Unity.SDK.Tests.EditMode.MwaClient
             _ = _client.Deauthorize(authToken);
 
             // Assert
-            var request = DecodeLastRequest();
-            Assert.IsNotNull(request.Params, "Params must not be null");
-            Assert.AreEqual(authToken, request.Params.AuthToken,
-                "Params.AuthToken must match the supplied authToken");
+            var paramsObject = DecodeLastParamsObject();
+            Assert.AreEqual(authToken, paramsObject.Value<string>("auth_token"),
+                "params.auth_token must match the supplied authToken");
         }
 
         [Test]
@@ -95,9 +117,9 @@ namespace Solana.Unity.SDK.Tests.EditMode.MwaClient
             // of the MWA spec for this RPC and must not leak into the payload.
             _ = _client.Deauthorize("auth-token");
 
-            var request = DecodeLastRequest();
-            Assert.IsNull(request.Params.Identity,
-                "Deauthorize must not send an Identity block (uri/icon/name)");
+            var paramsObject = DecodeLastParamsObject();
+            Assert.IsNull(paramsObject.Property("identity"),
+                "Deauthorize must not send an identity key in params");
         }
 
         [Test]
@@ -105,9 +127,9 @@ namespace Solana.Unity.SDK.Tests.EditMode.MwaClient
         {
             _ = _client.Deauthorize("auth-token");
 
-            var request = DecodeLastRequest();
-            Assert.IsNull(request.Params.Cluster,
-                "Deauthorize must not send a Cluster field");
+            var paramsObject = DecodeLastParamsObject();
+            Assert.IsNull(paramsObject.Property("cluster"),
+                "Deauthorize must not send a cluster key in params");
         }
 
         [Test]
@@ -115,11 +137,11 @@ namespace Solana.Unity.SDK.Tests.EditMode.MwaClient
         {
             _ = _client.Deauthorize("auth-token");
 
-            var request = DecodeLastRequest();
-            Assert.IsNull(request.Params.Payloads,
-                "Deauthorize must not send Payloads");
-            Assert.IsNull(request.Params.Addresses,
-                "Deauthorize must not send Addresses");
+            var paramsObject = DecodeLastParamsObject();
+            Assert.IsNull(paramsObject.Property("payloads"),
+                "Deauthorize must not send a payloads key in params");
+            Assert.IsNull(paramsObject.Property("addresses"),
+                "Deauthorize must not send an addresses key in params");
         }
 
         [Test]
@@ -127,8 +149,9 @@ namespace Solana.Unity.SDK.Tests.EditMode.MwaClient
         {
             _ = _client.Deauthorize("auth-token");
 
-            var request = DecodeLastRequest();
-            Assert.Greater(request.Id, 0, "Request Id must be a positive integer");
+            var request = DecodeLastRequestObject();
+            Assert.Greater(GetRequestId(request), 0,
+                "Request Id must be a positive integer");
         }
 
         [Test]
@@ -138,11 +161,11 @@ namespace Solana.Unity.SDK.Tests.EditMode.MwaClient
             _ = _client.Deauthorize("token-1");
             _ = _client.Deauthorize("token-2");
 
-            var first = DecodeRequestAt(0);
-            var second = DecodeRequestAt(1);
+            var first = DecodeRequestObjectAt(0);
+            var second = DecodeRequestObjectAt(1);
 
             // Assert
-            Assert.AreEqual(first.Id + 1, second.Id,
+            Assert.AreEqual(GetRequestId(first) + 1, GetRequestId(second),
                 "Each successive Deauthorize must have Id one greater than the previous");
         }
 
@@ -154,8 +177,11 @@ namespace Solana.Unity.SDK.Tests.EditMode.MwaClient
             Assert.DoesNotThrow(() => _client.Deauthorize(null),
                 "Deauthorize must not throw when authToken is null");
 
-            var request = DecodeLastRequest();
-            Assert.AreEqual("deauthorize", request.Method);
+            var request = DecodeLastRequestObject();
+            var paramsObject = DecodeLastParamsObject();
+            Assert.AreEqual("deauthorize", request.Value<string>("method"));
+            Assert.IsNull(paramsObject.Property("auth_token"),
+                "Null auth tokens must be omitted from params");
         }
 
         
@@ -165,8 +191,8 @@ namespace Solana.Unity.SDK.Tests.EditMode.MwaClient
         {
             _ = _client.GetCapabilities();
 
-            var request = DecodeLastRequest();
-            Assert.AreEqual("get_capabilities", request.Method,
+            var request = DecodeLastRequestObject();
+            Assert.AreEqual("get_capabilities", request.Value<string>("method"),
                 "Method must be 'get_capabilities' (snake_case per MWA spec)");
         }
 
@@ -175,8 +201,8 @@ namespace Solana.Unity.SDK.Tests.EditMode.MwaClient
         {
             _ = _client.GetCapabilities();
 
-            var request = DecodeLastRequest();
-            Assert.AreEqual("2.0", request.JsonRpc);
+            var request = DecodeLastRequestObject();
+            Assert.AreEqual("2.0", request.Value<string>("jsonrpc"));
         }
 
         [Test]
@@ -187,14 +213,9 @@ namespace Solana.Unity.SDK.Tests.EditMode.MwaClient
             // (which some MWA servers reject) is caught here.
             _ = _client.GetCapabilities();
 
-            var request = DecodeLastRequest();
-            Assert.IsNotNull(request.Params,
-                "GetCapabilities must send a non-null (empty) Params object");
-            Assert.IsNull(request.Params.Identity, "Params.Identity must be null");
-            Assert.IsNull(request.Params.Cluster, "Params.Cluster must be null");
-            Assert.IsNull(request.Params.AuthToken, "Params.AuthToken must be null");
-            Assert.IsNull(request.Params.Payloads, "Params.Payloads must be null");
-            Assert.IsNull(request.Params.Addresses, "Params.Addresses must be null");
+            var paramsObject = DecodeLastParamsObject();
+            Assert.IsFalse(paramsObject.HasValues,
+                "GetCapabilities must send an empty params object");
         }
 
         [Test]
@@ -202,8 +223,9 @@ namespace Solana.Unity.SDK.Tests.EditMode.MwaClient
         {
             _ = _client.GetCapabilities();
 
-            var request = DecodeLastRequest();
-            Assert.Greater(request.Id, 0, "Request Id must be a positive integer");
+            var request = DecodeLastRequestObject();
+            Assert.Greater(GetRequestId(request), 0,
+                "Request Id must be a positive integer");
         }
 
         [Test]
@@ -212,10 +234,10 @@ namespace Solana.Unity.SDK.Tests.EditMode.MwaClient
             _ = _client.GetCapabilities();
             _ = _client.GetCapabilities();
 
-            var first = DecodeRequestAt(0);
-            var second = DecodeRequestAt(1);
+            var first = DecodeRequestObjectAt(0);
+            var second = DecodeRequestObjectAt(1);
 
-            Assert.AreEqual(first.Id + 1, second.Id,
+            Assert.AreEqual(GetRequestId(first) + 1, GetRequestId(second),
                 "Each successive GetCapabilities must have Id one greater than the previous");
         }
 
@@ -246,14 +268,14 @@ namespace Solana.Unity.SDK.Tests.EditMode.MwaClient
             _ = _client.Deauthorize("auth-token");
             _ = _client.GetCapabilities();
 
-            var first = DecodeRequestAt(0);
-            var second = DecodeRequestAt(1);
-            var third = DecodeRequestAt(2);
+            var first = DecodeRequestObjectAt(0);
+            var second = DecodeRequestObjectAt(1);
+            var third = DecodeRequestObjectAt(2);
 
             // Assert, the client maintains a single monotonic id counter.
-            Assert.AreEqual(first.Id + 1, second.Id,
+            Assert.AreEqual(GetRequestId(first) + 1, GetRequestId(second),
                 "Deauthorize id must follow Authorize id by 1");
-            Assert.AreEqual(second.Id + 1, third.Id,
+            Assert.AreEqual(GetRequestId(second) + 1, GetRequestId(third),
                 "GetCapabilities id must follow Deauthorize id by 1");
         }
     }

--- a/Tests/EditMode/MwaClient/MobileWalletAdapterClientLifecycleTests.cs
+++ b/Tests/EditMode/MwaClient/MobileWalletAdapterClientLifecycleTests.cs
@@ -1,0 +1,260 @@
+using NUnit.Framework;
+using System.Reflection;
+using System.Text;
+using System.Threading.Tasks;
+using Newtonsoft.Json;
+using Solana.Unity.SDK.Tests.EditMode.Mocks;
+
+// ReSharper disable once CheckNamespace
+namespace Solana.Unity.SDK.Tests.EditMode.MwaClient
+{
+    /// <summary>
+    /// Edit mode tests for the lifecycle RPCs added in PR #269:
+    /// <c>Deauthorize(authToken)</c> and <c>GetCapabilities()</c>.
+    /// A mock sender captures the serialized JSON so tests can assert
+    /// the exact wire shape, method name, id sequencing, and param
+    /// whitelist without spinning up a real MWA session.
+    /// </summary>
+    [Category("Lifecycle")]
+    public class MobileWalletAdapterClientLifecycleTests
+    {
+        private MockMessageSender _sender;
+        private MobileWalletAdapterClient _client;
+
+        [SetUp]
+        public void SetUp()
+        {
+            _sender = new MockMessageSender();
+            _client = new MobileWalletAdapterClient(_sender);
+        }
+
+        
+        // Helpers
+
+        /// <summary>
+        /// Reads the last captured message and decodes it as JsonRequest.
+        /// Mirrors the helper in MobileWalletAdapterClientTests.cs.
+        /// </summary>
+        private JsonRequest DecodeLastRequest()
+        {
+            Assert.IsNotNull(_sender.LastMessage, "No message was sent to MockMessageSender");
+            var json = Encoding.UTF8.GetString(_sender.LastMessage);
+            return JsonConvert.DeserializeObject<JsonRequest>(json);
+        }
+
+        private JsonRequest DecodeRequestAt(int index)
+        {
+            var json = Encoding.UTF8.GetString(_sender.SentMessages[index]);
+            return JsonConvert.DeserializeObject<JsonRequest>(json);
+        }
+
+        
+        // Deauthorize request shape
+        [Test]
+        public void Deauthorize_SendsJsonRpc_WithCorrectMethod()
+        {
+            // Act
+            _ = _client.Deauthorize("test-auth-token-abc123");
+
+            // Assert
+            var request = DecodeLastRequest();
+            Assert.AreEqual("deauthorize", request.Method,
+                "Method must be 'deauthorize'");
+        }
+
+        [Test]
+        public void Deauthorize_SendsJsonRpc_WithVersion2_0()
+        {
+            _ = _client.Deauthorize("test-auth-token-abc123");
+
+            var request = DecodeLastRequest();
+            Assert.AreEqual("2.0", request.JsonRpc,
+                "JsonRpc version must be '2.0'");
+        }
+
+        [Test]
+        public void Deauthorize_SendsAuthToken_InParams()
+        {
+            // Arrange
+            const string authToken = "auth-token-xyz-789";
+
+            // Act
+            _ = _client.Deauthorize(authToken);
+
+            // Assert
+            var request = DecodeLastRequest();
+            Assert.IsNotNull(request.Params, "Params must not be null");
+            Assert.AreEqual(authToken, request.Params.AuthToken,
+                "Params.AuthToken must match the supplied authToken");
+        }
+
+        [Test]
+        public void Deauthorize_Params_DoesNotIncludeIdentity()
+        {
+            // Deauthorize is scoped to a token; identity fields are not part
+            // of the MWA spec for this RPC and must not leak into the payload.
+            _ = _client.Deauthorize("auth-token");
+
+            var request = DecodeLastRequest();
+            Assert.IsNull(request.Params.Identity,
+                "Deauthorize must not send an Identity block (uri/icon/name)");
+        }
+
+        [Test]
+        public void Deauthorize_Params_DoesNotIncludeCluster()
+        {
+            _ = _client.Deauthorize("auth-token");
+
+            var request = DecodeLastRequest();
+            Assert.IsNull(request.Params.Cluster,
+                "Deauthorize must not send a Cluster field");
+        }
+
+        [Test]
+        public void Deauthorize_Params_DoesNotIncludePayloadsOrAddresses()
+        {
+            _ = _client.Deauthorize("auth-token");
+
+            var request = DecodeLastRequest();
+            Assert.IsNull(request.Params.Payloads,
+                "Deauthorize must not send Payloads");
+            Assert.IsNull(request.Params.Addresses,
+                "Deauthorize must not send Addresses");
+        }
+
+        [Test]
+        public void Deauthorize_MessageId_IsPositive()
+        {
+            _ = _client.Deauthorize("auth-token");
+
+            var request = DecodeLastRequest();
+            Assert.Greater(request.Id, 0, "Request Id must be a positive integer");
+        }
+
+        [Test]
+        public void Deauthorize_MessageIds_AreIncrementing()
+        {
+            // Act - fire two requests
+            _ = _client.Deauthorize("token-1");
+            _ = _client.Deauthorize("token-2");
+
+            var first = DecodeRequestAt(0);
+            var second = DecodeRequestAt(1);
+
+            // Assert
+            Assert.AreEqual(first.Id + 1, second.Id,
+                "Each successive Deauthorize must have Id one greater than the previous");
+        }
+
+        [Test]
+        public void Deauthorize_DoesNotThrow_WhenAuthToken_IsNull()
+        {
+            // The client should defer validation to the wallet; a null token
+            // must still produce a well-formed request on the wire.
+            Assert.DoesNotThrow(() => _client.Deauthorize(null),
+                "Deauthorize must not throw when authToken is null");
+
+            var request = DecodeLastRequest();
+            Assert.AreEqual("deauthorize", request.Method);
+        }
+
+        
+        // GetCapabilities request shape
+        [Test]
+        public void GetCapabilities_SendsJsonRpc_WithCorrectMethod()
+        {
+            _ = _client.GetCapabilities();
+
+            var request = DecodeLastRequest();
+            Assert.AreEqual("get_capabilities", request.Method,
+                "Method must be 'get_capabilities' (snake_case per MWA spec)");
+        }
+
+        [Test]
+        public void GetCapabilities_SendsJsonRpc_WithVersion2_0()
+        {
+            _ = _client.GetCapabilities();
+
+            var request = DecodeLastRequest();
+            Assert.AreEqual("2.0", request.JsonRpc);
+        }
+
+        [Test]
+        public void GetCapabilities_SendsEmptyParams_NotNull()
+        {
+            // The implementation sends new JsonRequestParams() (empty object)
+            // rather than null. Pin that so a refactor that flips it to null
+            // (which some MWA servers reject) is caught here.
+            _ = _client.GetCapabilities();
+
+            var request = DecodeLastRequest();
+            Assert.IsNotNull(request.Params,
+                "GetCapabilities must send a non-null (empty) Params object");
+            Assert.IsNull(request.Params.Identity, "Params.Identity must be null");
+            Assert.IsNull(request.Params.Cluster, "Params.Cluster must be null");
+            Assert.IsNull(request.Params.AuthToken, "Params.AuthToken must be null");
+            Assert.IsNull(request.Params.Payloads, "Params.Payloads must be null");
+            Assert.IsNull(request.Params.Addresses, "Params.Addresses must be null");
+        }
+
+        [Test]
+        public void GetCapabilities_MessageId_IsPositive()
+        {
+            _ = _client.GetCapabilities();
+
+            var request = DecodeLastRequest();
+            Assert.Greater(request.Id, 0, "Request Id must be a positive integer");
+        }
+
+        [Test]
+        public void GetCapabilities_MessageIds_AreIncrementing()
+        {
+            _ = _client.GetCapabilities();
+            _ = _client.GetCapabilities();
+
+            var first = DecodeRequestAt(0);
+            var second = DecodeRequestAt(1);
+
+            Assert.AreEqual(first.Id + 1, second.Id,
+                "Each successive GetCapabilities must have Id one greater than the previous");
+        }
+
+        [Test]
+        public void GetCapabilities_ReturnType_IsTaskOfCapabilitiesResult()
+        {
+            // Locks the public return type so downstream callers do not
+            // silently break if the method signature changes.
+            var method = typeof(MobileWalletAdapterClient)
+                .GetMethod(nameof(MobileWalletAdapterClient.GetCapabilities),
+                    BindingFlags.Instance | BindingFlags.Public);
+
+            Assert.IsNotNull(method, "MobileWalletAdapterClient.GetCapabilities must exist");
+            Assert.AreEqual(typeof(Task<CapabilitiesResult>), method.ReturnType,
+                "GetCapabilities must return Task<CapabilitiesResult>");
+        }
+
+        
+        // Cross-method id sequence
+        [Test]
+        public void MixedCalls_ShareMessageIdSequence()
+        {
+            // Arrange
+            var identityUri = new System.Uri("https://example.com");
+
+            // Act, intermix three different RPCs
+            _ = _client.Authorize(identityUri, null, "TestApp", "mainnet-beta");
+            _ = _client.Deauthorize("auth-token");
+            _ = _client.GetCapabilities();
+
+            var first = DecodeRequestAt(0);
+            var second = DecodeRequestAt(1);
+            var third = DecodeRequestAt(2);
+
+            // Assert, the client maintains a single monotonic id counter.
+            Assert.AreEqual(first.Id + 1, second.Id,
+                "Deauthorize id must follow Authorize id by 1");
+            Assert.AreEqual(second.Id + 1, third.Id,
+                "GetCapabilities id must follow Deauthorize id by 1");
+        }
+    }
+}

--- a/Tests/EditMode/MwaClient/MobileWalletAdapterClientLifecycleTests.cs.meta
+++ b/Tests/EditMode/MwaClient/MobileWalletAdapterClientLifecycleTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 9f23bbf82a7e82a47b22339b9a404082


### PR DESCRIPTION
| Status  | Type  | ⚠️ Core Change | Issue |
| :---: | :---: | :---: | :--: |
| Ready | Tooling | No | Follow-up to #276 |

> NOTE: This PR adds EditMode test coverage for the MWA lifecycle work merged in #269 (`Deauthorize`, `GetCapabilities`, `keepConnectionAlive` auth-token restore, and the namespaced PlayerPrefs migration).
>
> Built on top of the test infrastructure introduced in #276. No runtime code is modified.
>
> Related PRs: #269, #276

## Problem

PR #269 added three new lifecycle surfaces to the Mobile Wallet Adapter stack:

- A new `Deauthorize(authToken)` RPC on `IAdapterOperations` / `MobileWalletAdapterClient`.
- A new `GetCapabilities()` RPC returning a new `CapabilitiesResult` response model.
- A `keepConnectionAlive` reauthorize path plus a PlayerPrefs migration from the legacy `pk` / `authToken` keys to namespaced `solana_sdk.mwa.public_key` / `solana_sdk.mwa.auth_token`.

None of that has automated coverage. A rename, a silent JSON property drift, or a regression in the key-migration logic would only surface during manual on-device testing, which is exactly the kind of failure the test infrastructure added in #276 was meant to prevent.

## Solution

This PR adds **44 new EditMode unit tests across 4 test classes**, using the `MockMessageSender` and NUnit conventions already established by #276.

Coverage added:

- **`CapabilitiesResultTests`** (11 tests): pins the snake_case JSON wire format (`max_transactions_per_request`, `max_messages_per_request`, `supported_transaction_versions`, `supports_clone_authorization`), verifies every nullable field stays `null` when absent (including `SupportsCloneAuthorization`, which is `bool?` and must not silently coerce to `false`), confirms unknown JSON fields are ignored for forward-compat with the MWA spec, and verifies `Response<CapabilitiesResult>` composes correctly with the existing `WasSuccessful` / `Failed` envelope flags.
- **`MobileWalletAdapterClientLifecycleTests`** (16 tests): asserts the exact JSON-RPC request shape sent to the wire for both new RPCs: method name (`deauthorize`, `get_capabilities`), JSON-RPC version, monotonic and positive message IDs, parameter whitelist (Deauthorize must *not* leak `identity`/`cluster`/`payloads`/`addresses`; GetCapabilities must send a non-null empty `Params` object), cross-method ID sequencing, and the public return type `Task<CapabilitiesResult>`.
- **`IAdapterOperationsContractTests`** (11 tests): reflection-based contract tests pinning every method signature on the interface. Guarantees `Deauthorize` returns the non-generic `Task` (fire-and-forget), `GetCapabilities` returns `Task<CapabilitiesResult>`, every method and the interface itself carry `[Preserve]` (required so IL2CPP / Unity managed code stripping does not remove them in AOT builds), and the method count stays locked at 6.
- **`SolanaMobileWalletAdapterPrefsTests`** (8 tests, `[Category("Lifecycle")]`): pins the private `const` key names (`solana_sdk.mwa.public_key`, `solana_sdk.mwa.auth_token`) so a rename breaks CI instead of users' existing installs, and exercises the private static `MigrateLegacyPrefKeys` via reflection. Covers: no-op when no legacy keys, migrates each legacy key independently, deletes legacy keys after migration, does not overwrite a newer namespaced value, idempotent on a second call, handles half-migrated installs. `[SetUp]` and `[TearDown]` scrub PlayerPrefs so the registry-backed store stays clean between runs.

Note: `SolanaMobileWalletAdapter` itself cannot be instantiated in EditMode because its constructor throws on non-Android platforms, this is the same blocker called out in the #276 PR body. Migration logic is reached through reflection to work around that without modifying runtime code.

## Before & After Screenshots

**BEFORE**:
34 passing EditMode tests (from #276). No coverage for PR #269's lifecycle surface.
<img width="849" height="1030" alt="test-framework" src="https://github.com/user-attachments/assets/c42bad51-fc6d-41d4-99be-50bada6defa6" />


**AFTER**:
78 passing EditMode tests in the Unity Test Runner.
<img width="711" height="1015" alt="image" src="https://github.com/user-attachments/assets/b33ae945-0326-42ac-b8a8-419f8b7e4602" />


## Other changes (e.g. bug fixes, small refactors)

- No runtime code is modified.
- No existing test is modified.
- No new assembly references added, all new tests compile against `com.solana.unity_sdk`, `Newtonsoft.Json.dll`, `nunit.framework.dll`, and the Unity test runners already referenced by `EditMode.asmdef`.
- New folder layout under `Tests/EditMode/`: `Contracts/`, `Lifecycle/` (plus files under the existing `JsonRpc/` and `MwaClient/`).

## Deploy Notes

Tooling-only. No runtime behavior change.

**New scripts**:

- `Tests/EditMode/JsonRpc/CapabilitiesResultTests.cs`
- `Tests/EditMode/MwaClient/MobileWalletAdapterClientLifecycleTests.cs`
- `Tests/EditMode/Contracts/IAdapterOperationsContractTests.cs`
- `Tests/EditMode/Lifecycle/SolanaMobileWalletAdapterPrefsTests.cs`

**New dependencies**:

- None

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added contract tests enforcing adapter public surface and method signatures.
  * Added JSON deserialization tests for capabilities responses, including missing/unknown-field handling.
  * Added preferences migration tests covering legacy-to-namespaced key behavior and idempotence.
  * Added client lifecycle tests validating JSON-RPC payloads, id sequencing, and method behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->