### PR TITLE
feat(mwa): add injectable auth token cache abstraction

### DIFF
--- a/Runtime/Plugins/SolanaMobileStack.meta
+++ b/Runtime/Plugins/SolanaMobileStack.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 32b67e33dececb5449a64363d0c280f3
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/Plugins/SolanaMobileStack/Android.meta
+++ b/Runtime/Plugins/SolanaMobileStack/Android.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 452d23bc9822c364aaf52989695e3f83
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/Plugins/SolanaMobileStack/Android/MwaChooserHelper.java
+++ b/Runtime/Plugins/SolanaMobileStack/Android/MwaChooserHelper.java
@@ -17,7 +17,10 @@ public final class MwaChooserHelper {
     // RECEIVER_NOT_EXPORTED (API 33) as literal for older compileSdk.
     private static final int RECEIVER_NOT_EXPORTED = 0x4;
 
+    private static final String EXTRA_NONCE = "chooser_nonce";
+
     private static volatile String sChosenPackage = null;
+    private static volatile String sChooserNonce = null;
     private static BroadcastReceiver sReceiver = null;
 
     private MwaChooserHelper() {}
@@ -32,9 +35,12 @@ public final class MwaChooserHelper {
     /** createChooser + IntentSender callback = launches MWA target intent */
     public static void launchWithChooser(Activity activity, Intent target, String title) {
         sChosenPackage = null;
+        sChooserNonce = java.util.UUID.randomUUID().toString();
         registerReceiver(activity.getApplicationContext());
 
-        Intent broadcast = new Intent(ACTION_CHOSEN).setPackage(activity.getPackageName());
+        Intent broadcast = new Intent(ACTION_CHOSEN)
+            .setPackage(activity.getPackageName())
+            .putExtra(EXTRA_NONCE, sChooserNonce);
 
         int flags = PendingIntent.FLAG_UPDATE_CURRENT;
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
@@ -53,6 +59,10 @@ public final class MwaChooserHelper {
         sReceiver = new BroadcastReceiver() {
             @Override
             public void onReceive(Context ctx, Intent intent) {
+                String nonce = intent.getStringExtra(EXTRA_NONCE);
+                if (nonce == null || !nonce.equals(sChooserNonce)) {
+                    return;
+                }
                 ComponentName chosen = intent.getParcelableExtra(Intent.EXTRA_CHOSEN_COMPONENT);
                 if (chosen != null) {
                     sChosenPackage = chosen.getPackageName();

--- a/Runtime/Plugins/SolanaMobileStack/Android/MwaChooserHelper.java
+++ b/Runtime/Plugins/SolanaMobileStack/Android/MwaChooserHelper.java
@@ -1,0 +1,69 @@
+package com.solana.unity.mwa;
+
+import android.app.Activity;
+import android.app.PendingIntent;
+import android.content.BroadcastReceiver;
+import android.content.ComponentName;
+import android.content.Context;
+import android.content.Intent;
+import android.content.IntentFilter;
+import android.os.Build;
+
+/** System wallet chooser + {@link Intent#EXTRA_CHOSEN_COMPONENT} capture. No manifest entry */
+public final class MwaChooserHelper {
+
+    private static final String ACTION_CHOSEN = "com.solana.unity.mwa.WALLET_CHOSEN";
+
+    // RECEIVER_NOT_EXPORTED (API 33) as literal for older compileSdk.
+    private static final int RECEIVER_NOT_EXPORTED = 0x4;
+
+    private static volatile String sChosenPackage = null;
+    private static BroadcastReceiver sReceiver = null;
+
+    private MwaChooserHelper() {}
+
+    /** Last chosen package, then clear. Null if none. */
+    public static synchronized String consumeChosenPackage() {
+        String pkg = sChosenPackage;
+        sChosenPackage = null;
+        return pkg;
+    }
+
+    /** createChooser + IntentSender callback = launches MWA target intent */
+    public static void launchWithChooser(Activity activity, Intent target, String title) {
+        sChosenPackage = null;
+        registerReceiver(activity.getApplicationContext());
+
+        Intent broadcast = new Intent(ACTION_CHOSEN).setPackage(activity.getPackageName());
+
+        int flags = PendingIntent.FLAG_UPDATE_CURRENT;
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+            flags |= PendingIntent.FLAG_MUTABLE;
+        }
+        PendingIntent pendingIntent = PendingIntent.getBroadcast(activity, 0, broadcast, flags);
+
+        Intent chooser = Intent.createChooser(target, title, pendingIntent.getIntentSender());
+        activity.startActivity(chooser);
+    }
+
+    private static synchronized void registerReceiver(Context context) {
+        if (sReceiver != null) {
+            return;
+        }
+        sReceiver = new BroadcastReceiver() {
+            @Override
+            public void onReceive(Context ctx, Intent intent) {
+                ComponentName chosen = intent.getParcelableExtra(Intent.EXTRA_CHOSEN_COMPONENT);
+                if (chosen != null) {
+                    sChosenPackage = chosen.getPackageName();
+                }
+            }
+        };
+        IntentFilter filter = new IntentFilter(ACTION_CHOSEN);
+        if (Build.VERSION.SDK_INT >= 33) {
+            context.registerReceiver(sReceiver, filter, RECEIVER_NOT_EXPORTED);
+        } else {
+            context.registerReceiver(sReceiver, filter);
+        }
+    }
+}

--- a/Runtime/Plugins/SolanaMobileStack/Android/MwaChooserHelper.java.meta
+++ b/Runtime/Plugins/SolanaMobileStack/Android/MwaChooserHelper.java.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: c2e599bcbcb4824449c5c30e4d9a32e7

--- a/Runtime/Plugins/SolanaWalletAdapterWebGL/SolanaWalletAdapterWebGL.jslib
+++ b/Runtime/Plugins/SolanaWalletAdapterWebGL/SolanaWalletAdapterWebGL.jslib
@@ -203,9 +203,11 @@ mergeInto(LibraryManager.library, {
           error: data && data.message ? String(data.message) : null,
         };
         const json = JSON.stringify(payload);
-        const ptr = _malloc(lengthBytesUTF8(json) + 1);
-        stringToUTF8(json, ptr, lengthBytesUTF8(json) + 1);
+        const len = lengthBytesUTF8(json) + 1;
+        const ptr = _malloc(len);
+        stringToUTF8(json, ptr, len);
         {{{ makeDynCall('vi', 'callback') }}}(ptr);
+        _free(ptr);
       };
 
       const tryResolveProvider = () => {
@@ -288,4 +290,3 @@ mergeInto(LibraryManager.library, {
     }
   },
 });
-

--- a/Runtime/Plugins/SolanaWalletAdapterWebGL/SolanaWalletAdapterWebGL.jslib
+++ b/Runtime/Plugins/SolanaWalletAdapterWebGL/SolanaWalletAdapterWebGL.jslib
@@ -168,4 +168,124 @@ mergeInto(LibraryManager.library, {
       {{{ makeDynCall('vi', 'callback') }}}(null);
     }
   },
+  ExternSubscribeWalletEvents: function (walletNamePtr, callback) {
+    try {
+      const walletName = UTF8ToString(walletNamePtr);
+      window.unityWalletEventUnsubs = window.unityWalletEventUnsubs || {};
+
+      if (window.unityWalletEventUnsubs[walletName]) {
+        window.unityWalletEventUnsubs[walletName]();
+        delete window.unityWalletEventUnsubs[walletName];
+      }
+
+      const toPkString = (v) => {
+        try {
+          if (!v) return null;
+          if (typeof v === "string") return v;
+          if (Array.isArray(v) && v.length > 0) {
+            const first = v[0];
+            if (!first) return null;
+            return typeof first === "string" ? first : (first.toString ? first.toString() : null);
+          }
+          return v.toString ? v.toString() : null;
+        } catch (_) {
+          return null;
+        }
+      };
+
+      const emit = (evt, data) => {
+        const payload = {
+          event: evt,
+          walletName: walletName,
+          publicKey: data && data.publicKey ? toPkString(data.publicKey) : toPkString(data),
+          account: data && data.account ? toPkString(data.account) : null,
+          accounts: data && data.accounts ? data.accounts.map(toPkString).filter(Boolean) : null,
+          error: data && data.message ? String(data.message) : null,
+        };
+        const json = JSON.stringify(payload);
+        const ptr = _malloc(lengthBytesUTF8(json) + 1);
+        stringToUTF8(json, ptr, lengthBytesUTF8(json) + 1);
+        {{{ makeDynCall('vi', 'callback') }}}(ptr);
+      };
+
+      const tryResolveProvider = () => {
+        if (walletName === "XNFT" && window.xnft && window.xnft.solana) {
+          return window.xnft.solana;
+        }
+
+        if (window.walletAdapterLib) {
+          if (typeof window.walletAdapterLib.getWalletAdapter === "function") {
+            const a = window.walletAdapterLib.getWalletAdapter(walletName);
+            if (a) return a;
+          }
+          if (typeof window.walletAdapterLib.getWalletByName === "function") {
+            const w = window.walletAdapterLib.getWalletByName(walletName);
+            if (w && w.adapter) return w.adapter;
+            if (w) return w;
+          }
+          const pools = [window.walletAdapterLib.walletAdapters, window.walletAdapterLib.wallets];
+          for (const pool of pools) {
+            if (!Array.isArray(pool)) continue;
+            for (const item of pool) {
+              if (!item) continue;
+              if (item.name === walletName) return item.adapter || item;
+              if (item.adapter && item.adapter.name === walletName) return item.adapter;
+              if (item.wallet && item.wallet.name === walletName) return item.wallet.adapter || item.wallet;
+            }
+          }
+        }
+
+        if (window.solana && walletName.toLowerCase().includes("phantom")) {
+          return window.solana;
+        }
+
+        return null;
+      };
+
+      const provider = tryResolveProvider();
+      if (!provider || typeof provider.on !== "function") {
+        return;
+      }
+
+      const subscriptions = [];
+      const on = (evt, fn) => {
+        try {
+          provider.on(evt, fn);
+          subscriptions.push([evt, fn]);
+        } catch (_) {}
+      };
+
+      on("accountsChanged", (accounts) => emit("accountsChanged", { accounts }));
+      on("accountChanged", (account) => emit("accountChanged", { account }));
+      on("disconnect", (info) => emit("disconnect", info));
+      on("connect", (info) => emit("connect", info));
+      on("change", (info) => emit("change", info));
+
+      window.unityWalletEventUnsubs[walletName] = () => {
+        if (typeof provider.off === "function") {
+          subscriptions.forEach(([evt, fn]) => {
+            try {
+              provider.off(evt, fn);
+            } catch (_) {}
+          });
+        }
+      };
+    } catch (err) {
+      console.error(err && err.message ? err.message : err);
+    }
+  },
+
+  ExternUnsubscribeWalletEvents: function (walletNamePtr) {
+    try {
+      const walletName = UTF8ToString(walletNamePtr);
+      if (!window.unityWalletEventUnsubs || !window.unityWalletEventUnsubs[walletName]) {
+        return;
+      }
+      window.unityWalletEventUnsubs[walletName]();
+      delete window.unityWalletEventUnsubs[walletName];
+    } catch (err) {
+      console.error(err && err.message ? err.message : err);
+    }
+  },
 });
+

--- a/Runtime/codebase/SessionWallet.cs
+++ b/Runtime/codebase/SessionWallet.cs
@@ -28,14 +28,12 @@ namespace Solana.Unity.SDK
             string customRpcUri = null, string customStreamingRpcUri = null,
             bool autoConnectOnStartup = false) : base(rpcCluster, customRpcUri, customStreamingRpcUri, autoConnectOnStartup)
         {
-            if (Instance == null)
+            if (Instance != null)
             {
-                Instance = this;
+                Debug.LogWarning($"there are more than one {nameof(SessionWallet)} in the scene");
             }
-            else
-            {
-                throw new Exception("SessionWallet already exists");
-            }
+
+            Instance = this;
         }
 
         /// <summary>
@@ -65,6 +63,24 @@ namespace Solana.Unity.SDK
         {
             tx.PartialSign(new[] { _externalWallet.Account, Account });
         }
+        
+        public static SessionWallet GetSessionWallet(string publicKey, string privateKey, PublicKey targetProgram)
+        {
+            _externalWallet = Web3.Wallet;
+
+            var sessionAccount = new Account(privateKey, publicKey); 
+            
+            // TODO: ActiveRpcClient can be null, get node address some other way
+            var sessionWallet = new SessionWallet(_externalWallet.RpcCluster, _externalWallet.ActiveRpcClient.NodeAddress.ToString())
+            {
+                TargetProgram = targetProgram,
+                EncryptedKeystoreKey = $"{_externalWallet.Account.PublicKey}_SessionKeyStore",
+                SessionTokenPDA = FindSessionToken(targetProgram, sessionAccount, _externalWallet.Account),
+                Account = sessionAccount,
+            };
+
+            return sessionWallet;
+        }
 
         /// <summary>
         /// Creates a new SessionWallet instance based on the signature we get from signing a specific message.
@@ -75,9 +91,6 @@ namespace Solana.Unity.SDK
         /// <returns>A SessionWallet instance.</returns>
         public static async Task<SessionWallet> GetSessionWallet(PublicKey targetProgram, WalletBase externalWallet = null, string seed = "MagicBlock.SessionKey")
         {
-            // TODO: This class behaves like a singleton, what if I want multiple session wallets active at the same time?
-            if (Instance != null) return Instance;
-            
             externalWallet ??= Web3.Wallet;
             _externalWallet = externalWallet;
             
@@ -108,8 +121,6 @@ namespace Solana.Unity.SDK
         /// <returns>A SessionWallet instance.</returns>
         public static async Task<SessionWallet> GetSessionWallet(PublicKey targetProgram, string password, WalletBase externalWallet = null)
         {
-            if (Instance != null) return Instance;
-            
             externalWallet ??= Web3.Wallet;
             _externalWallet = externalWallet;
             
@@ -131,6 +142,7 @@ namespace Solana.Unity.SDK
                     sessionWallet.DeleteSessionWallet();
                     sessionWallet.Logout();
                     Instance = null;
+                    
                     return await GetSessionWallet(targetProgram, password, externalWallet);
                 }
 

--- a/Runtime/codebase/SessionWallet.cs
+++ b/Runtime/codebase/SessionWallet.cs
@@ -67,6 +67,8 @@ namespace Solana.Unity.SDK
         public static SessionWallet GetSessionWallet(string publicKey, string privateKey, PublicKey targetProgram)
         {
             _externalWallet = Web3.Wallet;
+            if (_externalWallet?.ActiveRpcClient == null)
+                throw new InvalidOperationException("Web3.Wallet and its ActiveRpcClient must be initialized before creating a SessionWallet from raw keys.");
 
             var sessionAccount = new Account(privateKey, publicKey); 
             

--- a/Runtime/codebase/SolanaMobileStack/IMwaWalletSelectionCache.cs
+++ b/Runtime/codebase/SolanaMobileStack/IMwaWalletSelectionCache.cs
@@ -1,0 +1,16 @@
+using System.Threading.Tasks;
+
+// ReSharper disable once CheckNamespace
+
+namespace Solana.Unity.SDK
+{
+    /// <summary>
+    /// Stores the selected Android wallet package used for MWA association.
+    /// </summary>
+    public interface IMwaWalletSelectionCache
+    {
+        Task<string> GetSelectedWalletPackage();
+        Task SetSelectedWalletPackage(string packageName);
+        Task ClearSelectedWalletPackage();
+    }
+}

--- a/Runtime/codebase/SolanaMobileStack/IMwaWalletSelectionCache.cs.meta
+++ b/Runtime/codebase/SolanaMobileStack/IMwaWalletSelectionCache.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 83ea841b08bad1b4d8dc0fe35aba1854
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/codebase/SolanaMobileStack/LocalAssociationIntentCreator.cs
+++ b/Runtime/codebase/SolanaMobileStack/LocalAssociationIntentCreator.cs
@@ -5,7 +5,8 @@ using UnityEngine;
 public static class LocalAssociationIntentCreator
 {
     
-    public static AndroidJavaObject CreateAssociationIntent(string associationToken, int port)
+    public static AndroidJavaObject CreateAssociationIntent(
+        string associationToken, int port, string targetPackage = null)
     {
         var intent = new AndroidJavaObject("android.content.Intent");
         intent.Call<AndroidJavaObject>("setAction", "android.intent.action.VIEW");
@@ -13,9 +14,15 @@ public static class LocalAssociationIntentCreator
         var url = $"{AssociationContract.SchemeMobileWalletAdapter}:/" +
                   $"{AssociationContract.LocalPathSuffix}?association={associationToken}&port={port}";
         var uriClass = new AndroidJavaClass("android.net.Uri");
-        var uriData = uriClass.CallStatic<AndroidJavaObject>("parse", url);     
+        var uriData = uriClass.CallStatic<AndroidJavaObject>("parse", url);
         intent.Call<AndroidJavaObject>("setData", uriData);
-        //intent.Call<AndroidJavaObject>("addFlags", 0x14000000);
+
+        if (!string.IsNullOrEmpty(targetPackage))
+        {
+            intent.Call<AndroidJavaObject>("setPackage", targetPackage);
+            UnityEngine.Debug.Log($"[MWA] Intent targeting package: {targetPackage}");
+        }
+
         return intent;
     }
 }

--- a/Runtime/codebase/SolanaMobileStack/LocalAssociationScenario.cs
+++ b/Runtime/codebase/SolanaMobileStack/LocalAssociationScenario.cs
@@ -288,7 +288,7 @@ public class LocalAssociationScenario : IDisposable
                 var json = System.Text.Encoding.UTF8.GetString(decrypted);
                 _client.Receive(json);
 
-                LogFullMessage("[MWA] Received message", json);
+                Debug.Log($"[MWA] Received encrypted message");
 
                 var response = JsonConvert.DeserializeObject<Response<object>>(json);
                 _responseTcs.TrySetResult(response);
@@ -298,33 +298,6 @@ public class LocalAssociationScenario : IDisposable
         {
             Debug.Log($"[MWA] Message handler error: {ex}");
             _responseTcs.TrySetException(ex);
-        }
-    }
-
-    // Logs a payload in full. logcat truncates a single line at ~4000 chars, so
-    // long messages are split into chunks to avoid losing the tail.
-    private static void LogFullMessage(string prefix, string payload)
-    {
-        const int chunkSize = 3500;
-
-        if (payload == null)
-        {
-            Debug.Log($"{prefix}: <null>");
-            return;
-        }
-
-        if (payload.Length <= chunkSize)
-        {
-            Debug.Log($"{prefix}: {payload}");
-            return;
-        }
-
-        var parts = (payload.Length + chunkSize - 1) / chunkSize;
-        for (var i = 0; i < parts; i++)
-        {
-            var start = i * chunkSize;
-            var len = Math.Min(chunkSize, payload.Length - start);
-            Debug.Log($"{prefix} [{i + 1}/{parts}]: {payload.Substring(start, len)}");
         }
     }
 

--- a/Runtime/codebase/SolanaMobileStack/LocalAssociationScenario.cs
+++ b/Runtime/codebase/SolanaMobileStack/LocalAssociationScenario.cs
@@ -171,9 +171,18 @@ public class LocalAssociationScenario : IDisposable
     {
         var intent = LocalAssociationIntentCreator.CreateAssociationIntent(
             associationToken, port, _targetPackage);
-        _currentActivity.Call("startActivityForResult", intent, 0);
-        Debug.Log($"[MWA] Launched intent for port {port}" +
-                  (string.IsNullOrEmpty(_targetPackage) ? "" : $" targeting {_targetPackage}"));
+
+        if (string.IsNullOrEmpty(_targetPackage))
+        {
+            // No cache = OS chooser + capture picked package(EXTRA_CHOSEN_COMPONENT)
+            MwaNativeChooser.LaunchWithChooser(_currentActivity, intent, "Connect wallet");
+            Debug.Log($"[MWA] Launched chooser intent for port {port}");
+        }
+        else
+        {
+            _currentActivity.Call("startActivityForResult", intent, 0);
+            Debug.Log($"[MWA] Launched intent for port {port} targeting {_targetPackage}");
+        }
     }
 
     private async Task ConnectWithBackoffAsync()

--- a/Runtime/codebase/SolanaMobileStack/LocalAssociationScenario.cs
+++ b/Runtime/codebase/SolanaMobileStack/LocalAssociationScenario.cs
@@ -288,7 +288,7 @@ public class LocalAssociationScenario : IDisposable
                 var json = System.Text.Encoding.UTF8.GetString(decrypted);
                 _client.Receive(json);
 
-                Debug.Log($"[MWA] Received encrypted message");
+                LogFullMessage("[MWA] Received message", json);
 
                 var response = JsonConvert.DeserializeObject<Response<object>>(json);
                 _responseTcs.TrySetResult(response);
@@ -298,6 +298,33 @@ public class LocalAssociationScenario : IDisposable
         {
             Debug.Log($"[MWA] Message handler error: {ex}");
             _responseTcs.TrySetException(ex);
+        }
+    }
+
+    // Logs a payload in full. logcat truncates a single line at ~4000 chars, so
+    // long messages are split into chunks to avoid losing the tail.
+    private static void LogFullMessage(string prefix, string payload)
+    {
+        const int chunkSize = 3500;
+
+        if (payload == null)
+        {
+            Debug.Log($"{prefix}: <null>");
+            return;
+        }
+
+        if (payload.Length <= chunkSize)
+        {
+            Debug.Log($"{prefix}: {payload}");
+            return;
+        }
+
+        var parts = (payload.Length + chunkSize - 1) / chunkSize;
+        for (var i = 0; i < parts; i++)
+        {
+            var start = i * chunkSize;
+            var len = Math.Min(chunkSize, payload.Length - start);
+            Debug.Log($"{prefix} [{i + 1}/{parts}]: {payload.Substring(start, len)}");
         }
     }
 

--- a/Runtime/codebase/SolanaMobileStack/LocalAssociationScenario.cs
+++ b/Runtime/codebase/SolanaMobileStack/LocalAssociationScenario.cs
@@ -98,7 +98,7 @@ public class LocalAssociationScenario : IDisposable
                     Debug.Log($"[MWA] Invoking action {action.Method.Name}");
                     action.Invoke(_client);
                 
-                    lastResponse = await _responseTcs.Task;
+                    lastResponse = await AwaitWithCancellation(_responseTcs.Task, _cancellationToken);
                     _responseTcs = null;
 
                     _cancellationToken.ThrowIfCancellationRequested();
@@ -221,7 +221,7 @@ public class LocalAssociationScenario : IDisposable
             Debug.Log($"[MWA] Connect attempt {attempt}, state: {_webSocket.State}");
             _webSocket.Connect();
             
-            var success = await _wsConnected.Task;
+            var success = await AwaitWithCancellation(_wsConnected.Task, _cancellationToken);
             Debug.Log($"[MWA] Connect attempt {attempt} result, state: {_webSocket.State}");
             
             if (success)
@@ -254,27 +254,33 @@ public class LocalAssociationScenario : IDisposable
     private void OnWsClose(WebSocketCloseCode closeCode)
     {
         Debug.Log($"[MWA] WS Closed: {closeCode}");
-        if (closeCode == WebSocketCloseCode.Normal) 
+
+        if (_isConnecting)
+        {
+            _wsConnected?.TrySetResult(false);
+            return;
+        }
+
+        if (closeCode == WebSocketCloseCode.Normal)
             return;
 
-        if (!_isConnecting)
-        {
-            var exc = new Exception($"[MWA] WS closed unexpectedly: {closeCode}");
-            _responseTcs?.TrySetException(exc);
-            _tcs?.TrySetException(exc);
-        }
-        else
-        {
-            _wsConnected.TrySetResult(false);
-        }
+        var exc = new Exception($"[MWA] WS closed unexpectedly: {closeCode}");
+        _responseTcs?.TrySetException(exc);
+        _tcs?.TrySetException(exc);
     }
 
     private void OnWsError(string message)
     {
         if (_isConnecting)
+        {
             _wsConnected?.TrySetResult(false);
+        }
         else
-            _tcs?.TrySetException(new Exception($"[MWA] WS error: {message}"));
+        {
+            var exc = new Exception($"[MWA] WS error: {message}");
+            _responseTcs?.TrySetException(exc);
+            _tcs?.TrySetException(exc);
+        }
     }
 
     private void OnWsMessage(byte[] bytes)
@@ -306,8 +312,21 @@ public class LocalAssociationScenario : IDisposable
         catch (Exception ex)
         {
             Debug.Log($"[MWA] Message handler error: {ex}");
-            _responseTcs.TrySetException(ex);
+            _responseTcs?.TrySetException(ex);
+            _tcs?.TrySetException(ex);
+            _wsConnected?.TrySetException(ex);
         }
+    }
+
+    private static async Task<T> AwaitWithCancellation<T>(Task<T> task, CancellationToken ct)
+    {
+        var cancelTcs = new TaskCompletionSource<bool>();
+        using (ct.Register(() => cancelTcs.TrySetResult(true)))
+        {
+            if (await Task.WhenAny(task, cancelTcs.Task) != task)
+                throw new OperationCanceledException(ct);
+        }
+        return await task;
     }
 
     private Task WaitForKeyExchangeAsync(CancellationToken ct)

--- a/Runtime/codebase/SolanaMobileStack/LocalAssociationScenario.cs
+++ b/Runtime/codebase/SolanaMobileStack/LocalAssociationScenario.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 using NativeWebSocket;
 using Newtonsoft.Json;
@@ -11,137 +12,334 @@ using WebSocketState = NativeWebSocket.WebSocketState;
 
 // ReSharper disable once CheckNamespace
 
-public class LocalAssociationScenario
+public class LocalAssociationScenario : IDisposable
 {
-    private readonly TimeSpan _clientTimeoutMs;
-    private readonly MobileWalletAdapterSession _session;
-    private readonly int _port;
-    private readonly IWebSocket _webSocket;
-    private AndroidJavaObject _nativeLocalAssociationScenario;
-    private TaskCompletionSource<Response<object>> _startAssociationTaskCompletionSource;
+    private readonly TimeSpan _overallTimeout = TimeSpan.FromSeconds(30);
+    private readonly TimeSpan _keyExchangeTimeout = TimeSpan.FromSeconds(20);
 
-    private bool _didConnect;
-    private bool _handledEncryptedMessage;
+    private readonly AndroidJavaObject _currentActivity = GetCurrentActivity();
+    private readonly int _port = RandomPort();
+    private readonly MobileWalletAdapterSession _session = new();
+    private readonly string _targetPackage;
+    private IWebSocket _webSocket;
     private MobileWalletAdapterClient _client;
-    private readonly AndroidJavaObject _currentActivity;
-    private Queue<Action<IAdapterOperations>> _actions;
 
-    public LocalAssociationScenario(int clientTimeoutMs = 9000)
+
+    private bool _isConnecting;
+    private bool _disposed;
+
+    private TaskCompletionSource<bool> _wsConnected;
+    private TaskCompletionSource<Response<object>> _responseTcs;
+    private TaskCompletionSource<Response<object>> _tcs;
+    private CancellationToken _cancellationToken;
+    private CancellationTokenSource _runCts;
+    private bool _seenFocusLossAfterLaunch;
+    private bool _focusReturnedBeforeConnect;
+
+    public LocalAssociationScenario(string targetPackage = null)
+    {
+        _targetPackage = targetPackage;
+    }
+
+    private static AndroidJavaObject GetCurrentActivity()
     {
         var unityPlayer = new AndroidJavaClass("com.unity3d.player.UnityPlayer");
-        _currentActivity = unityPlayer.GetStatic<AndroidJavaObject>("currentActivity");
-        _clientTimeoutMs = TimeSpan.FromSeconds(clientTimeoutMs);
-        _port = Random.Range(WebSocketsTransportContract.WebsocketsLocalPortMin, WebSocketsTransportContract.WebsocketsLocalPortMax + 1);
-        _session = new MobileWalletAdapterSession();
-        var webSocketUri = WebSocketsTransportContract.WebsocketsLocalScheme + "://" + WebSocketsTransportContract.WebsocketsLocalHost + ":" + _port + WebSocketsTransportContract.WebsocketsLocalPath;
-        _webSocket = WebSocket.Create(webSocketUri, WebSocketsTransportContract.WebsocketsProtocol);
-        _webSocket.OnOpen += () =>
-        {
-            if(_didConnect)return;
-            _didConnect = true;
-            var helloReq = _session.CreateHelloReq();
-            _webSocket.Send(helloReq);
-            ListenKeyExchange();
-        };
-        _webSocket.OnClose += (e) =>
-        {
-            if (!_didConnect) return;
-            _webSocket.Connect(awaitConnection: false);
-        };
-        _webSocket.OnError += (e) =>
-        {
-            Debug.Log("WebSocket Error: " + e);
-        };
-        _webSocket.OnMessage += ReceivePublicKeyHandler;
+        return unityPlayer.GetStatic<AndroidJavaObject>("currentActivity");
     }
 
-
-    public Task<Response<object>> StartAndExecute(List<Action<IAdapterOperations>> actions)
+    public async Task<Response<object>> StartAndExecute(List<Action<IAdapterOperations>> actions,
+        CancellationToken ct = default)
     {
         if (actions == null || actions.Count == 0)
-            throw new ArgumentException("Actions must be non-null and non-empty");
-        _actions = new Queue<Action<IAdapterOperations>>(actions);
+            throw new ArgumentException("Actions required");
+
+        using var cts = CancellationTokenSource.CreateLinkedTokenSource(ct);
+        _runCts = cts;
+        _runCts.CancelAfter(_overallTimeout);
+
+        _cancellationToken = _runCts.Token;
+        _tcs = new TaskCompletionSource<Response<object>>();
+        _seenFocusLossAfterLaunch = false;
+        _focusReturnedBeforeConnect = false;
+        Application.focusChanged += OnApplicationFocusChanged;
+
+        StartActivityForAssociation(_session.AssociationToken, _port);
+
+        Debug.Log("[MWA] Waiting for websocket connection");
+        await Task.Run(async () =>
+        {
+            try
+            {
+                Debug.Log("[MWA Connect Thread] Started");
+                _isConnecting = true;
+            
+                await ConnectWithBackoffAsync();
+            
+                Debug.Log("[MWA Connect Thread] Completed");
+                _isConnecting = false;
+
+                var helloReq = _session.CreateHelloReq();
+                await _webSocket.Send(helloReq);
+
+                Debug.Log("[MWA] Hello sent. Waiting for pubkey...");
+
+                await WaitForKeyExchangeAsync(cts.Token);
+
+                Debug.Log("[MWA] Pubkey received, session is encrypted");
+            
+                var queue = new Queue<Action<IAdapterOperations>>(actions);
+                Response<object> lastResponse = null;
+
+                while (queue.Count > 0)
+                {
+                    _responseTcs = new TaskCompletionSource<Response<object>>();
+                
+                    var action = queue.Dequeue();
+                    Debug.Log($"[MWA] Invoking action {action.Method.Name}");
+                    action.Invoke(_client);
+                
+                    lastResponse = await _responseTcs.Task;
+                    _responseTcs = null;
+
+                    _cancellationToken.ThrowIfCancellationRequested();
+                }
+
+                _tcs.TrySetResult(lastResponse ?? new Response<object>());
+            }
+            catch (OperationCanceledException)
+            {
+                var msg = _focusReturnedBeforeConnect
+                    ? "Association aborted: returned to app before wallet websocket connected"
+                    : "Timeout or cancelled";
+                _tcs.TrySetResult(new Response<object>
+                {
+                    Error = new Response<object>.ResponseError { Message = msg } 
+                });
+            }
+            catch (Exception ex)
+            {
+                Debug.Log($"[MWA] Association failed: {ex}");
+                _tcs.TrySetException(ex);
+            }
+            finally
+            {
+                await CleanupAsync();
+            }
+        }, _runCts.Token);
+        
+        return await _tcs.Task;
+    }
+
+    private void OnApplicationFocusChanged(bool hasFocus)
+    {
+        if (!hasFocus)
+        {
+            _seenFocusLossAfterLaunch = true;
+            return;
+        }
+
+        if (!_seenFocusLossAfterLaunch)
+        {
+            return;
+        }
+
+        if (_isConnecting && (_webSocket == null || _webSocket.State != WebSocketState.Open))
+        {
+            _focusReturnedBeforeConnect = true;
+            Debug.LogWarning("[MWA] Focus returned before WS connected; aborting association attempt early.");
+            _runCts?.Cancel();
+        }
+    }
+
+    private static int RandomPort()
+    {
+        return Random.Range(WebSocketsTransportContract.WebsocketsLocalPortMin,
+            WebSocketsTransportContract.WebsocketsLocalPortMax + 1);
+    }
+
+    private static IWebSocket CreateWebSocket(int port)
+    {
+        var webSocketUri = WebSocketsTransportContract.WebsocketsLocalScheme + "://" +
+                           WebSocketsTransportContract.WebsocketsLocalHost + ":" + port +
+                           WebSocketsTransportContract.WebsocketsLocalPath;
+        
+        Debug.Log($"[MWA] Websocket created with URI {webSocketUri}");
+        return WebSocket.Create(webSocketUri, WebSocketsTransportContract.WebsocketsProtocol);
+    }
+
+    private void StartActivityForAssociation(string associationToken, int port)
+    {
         var intent = LocalAssociationIntentCreator.CreateAssociationIntent(
-            _session.AssociationToken, 
-            _port);
+            associationToken, port, _targetPackage);
         _currentActivity.Call("startActivityForResult", intent, 0);
-        _currentActivity.Call("runOnUiThread", new AndroidJavaRunnable(TryConnectWs));
-        _startAssociationTaskCompletionSource = new TaskCompletionSource<Response<object>>();
-        return _startAssociationTaskCompletionSource.Task;
+        Debug.Log($"[MWA] Launched intent for port {port}" +
+                  (string.IsNullOrEmpty(_targetPackage) ? "" : $" targeting {_targetPackage}"));
     }
-    
-    private async void TryConnectWs()
+
+    private async Task ConnectWithBackoffAsync()
     {
-        var timeout = _clientTimeoutMs;
-        while (_webSocket.State != WebSocketState.Open && !_didConnect && timeout.TotalSeconds > 0)
+        const int maxAttempts = 12;
+        const int delayStart = 400;
+        const int delayCap = 3000;
+
+        var attempt = 0;
+        var delayMs = delayStart;
+
+        // Short delay to give wallet time to start websocket
+        await Task.Delay(500, _cancellationToken);
+
+        do
         {
-            await _webSocket.Connect(awaitConnection: false);
-            var timeDelta = TimeSpan.FromMilliseconds(500);
-            timeout -= timeDelta;
-            await Task.Delay(timeDelta);
-        }
-        if (_webSocket.State != WebSocketState.Open)
-        {
-            Debug.Log("Error: timeout");
-        }
+            if (_webSocket != null)
+            {
+                _webSocket.OnOpen -= OnWsOpen;
+                _webSocket.OnError -= OnWsError;
+                _webSocket.OnClose -= OnWsClose;
+                _webSocket.OnMessage -= OnWsMessage;
+                _webSocket = null;
+            }
+        
+            _webSocket = CreateWebSocket(_port);
+            _webSocket.OnOpen += OnWsOpen;
+            _webSocket.OnError += OnWsError;
+            _webSocket.OnClose += OnWsClose;
+            _webSocket.OnMessage += OnWsMessage;
+            
+            var startTime = DateTime.UtcNow;
+            _wsConnected = new TaskCompletionSource<bool>();
+            
+            attempt++;
+            Debug.Log($"[MWA] Connect attempt {attempt}, state: {_webSocket.State}");
+            _webSocket.Connect();
+            
+            var success = await _wsConnected.Task;
+            Debug.Log($"[MWA] Connect attempt {attempt} result, state: {_webSocket.State}");
+            
+            if (success)
+                return;
+            
+            var duration = (int)(DateTime.UtcNow - startTime).TotalMilliseconds;
+            if (duration < delayMs)
+            {
+                await Task.Delay(delayMs - duration, _cancellationToken);
+            }
+            
+            delayMs = Math.Min(delayMs * 2, delayCap);
+            
+        } while (_webSocket.State != WebSocketState.Open && !_cancellationToken.IsCancellationRequested &&
+                 attempt < maxAttempts);
+
+        throw new TimeoutException("[MWA] WebSocket connect timed out after max attempts");
     }
 
-    private async void ListenKeyExchange()
+    private void OnWsOpen()
     {
-        while (!_handledEncryptedMessage)
+        Debug.Log("[MWA] WS Opened");
+
+        if (_isConnecting)
         {
-            var timeDelta = TimeSpan.FromMilliseconds(300);
-            await Task.Delay(timeDelta);
+            _wsConnected.TrySetResult(true);
         }
     }
 
-    private void HandleEncryptedSessionPayload(byte[] e)
+    private void OnWsClose(WebSocketCloseCode closeCode)
     {
-        if (!_didConnect)
-        {
-            throw new InvalidOperationException("Invalid message received; terminating session");
-        }
+        Debug.Log($"[MWA] WS Closed: {closeCode}");
+        if (closeCode == WebSocketCloseCode.Normal) 
+            return;
 
-        var de = _session.DecryptSessionPayload(e);
-        var message = System.Text.Encoding.UTF8.GetString(de);
-        _client.Receive(message);
-        var receivedResponse = JsonConvert.DeserializeObject<Response<object>>(message);;
-        ExecuteNextAction(receivedResponse);
+        if (!_isConnecting)
+        {
+            var exc = new Exception($"[MWA] WS closed unexpectedly: {closeCode}");
+            _responseTcs?.TrySetException(exc);
+            _tcs?.TrySetException(exc);
+        }
+        else
+        {
+            _wsConnected.TrySetResult(false);
+        }
     }
 
+    private void OnWsError(string message)
+    {
+        if (_isConnecting)
+            _wsConnected?.TrySetResult(false);
+        else
+            _tcs?.TrySetException(new Exception($"[MWA] WS error: {message}"));
+    }
 
-    private void ReceivePublicKeyHandler(byte[] m)
+    private void OnWsMessage(byte[] bytes)
     {
         try
         {
-            _session.GenerateSessionEcdhSecret(m);
-            var messageSender = new MobileWalletAdapterWebSocket(_webSocket, _session);
-            _client = new MobileWalletAdapterClient(messageSender);
-            _webSocket.OnMessage -= ReceivePublicKeyHandler;
-            _webSocket.OnMessage += HandleEncryptedSessionPayload;
-            
-            // Executing the first action
-            ExecuteNextAction();
+            // First message expected: raw pubkey for ECDH
+            if (_client == null)
+            {
+                _session.GenerateSessionEcdhSecret(bytes);
+                var messageSender = new MobileWalletAdapterWebSocket(_webSocket, _session);
+                _client = new MobileWalletAdapterClient(messageSender);
+
+                Debug.Log("[MWA] Key exchange complete → encrypted session ready");
+            }
+            // All other should be encrypted messages
+            else
+            {
+                var decrypted = _session.DecryptSessionPayload(bytes);
+                var json = System.Text.Encoding.UTF8.GetString(decrypted);
+                _client.Receive(json);
+
+                Debug.Log($"[MWA] Received encrypted message");
+
+                var response = JsonConvert.DeserializeObject<Response<object>>(json);
+                _responseTcs.TrySetResult(response);
+            }
         }
-        catch (Exception e)
+        catch (Exception ex)
         {
-            Console.WriteLine(e);
+            Debug.Log($"[MWA] Message handler error: {ex}");
+            _responseTcs.TrySetException(ex);
         }
     }
 
-    private void ExecuteNextAction(Response<object> response = null)
+    private Task WaitForKeyExchangeAsync(CancellationToken ct)
     {
-        if (_actions.Count == 0 || response is { Failed: true })
-            CloseAssociation(response);
-        var action = _actions.Dequeue();
-        action.Invoke(_client);
+        return Task.Run(async () =>
+        {
+            var start = DateTime.UtcNow;
+            while (_client == null)
+            {
+                if (ct.IsCancellationRequested || DateTime.UtcNow - start > _keyExchangeTimeout)
+                    throw new TimeoutException("[MWA] Key exchange timed out");
+
+                await Task.Delay(200, ct);
+            }
+        }, ct);
     }
 
-    private async void CloseAssociation(Response<object> response)
+    private async Task CleanupAsync()
     {
-        _webSocket.OnMessage -= HandleEncryptedSessionPayload;
-        _handledEncryptedMessage = true;
-        await _webSocket.Close();
-        _startAssociationTaskCompletionSource.SetResult(response);
+        Application.focusChanged -= OnApplicationFocusChanged;
+
+        if (_webSocket is { State: WebSocketState.Open })
+            await _webSocket.Close();
+
+        if (_webSocket != null)
+        {
+            _webSocket.OnOpen -= OnWsOpen;
+            _webSocket.OnMessage -= OnWsMessage;
+            _webSocket.OnError -= OnWsError;
+            _webSocket.OnClose -= OnWsClose;
+            _webSocket = null;
+        }
+        
+        _client = null;
+        _runCts = null;
+        _disposed = true;
+    }
+
+    void IDisposable.Dispose()
+    {
+        if (_disposed) return;
+        _ = CleanupAsync();
     }
 }

--- a/Runtime/codebase/SolanaMobileStack/MwaAuthCache.meta
+++ b/Runtime/codebase/SolanaMobileStack/MwaAuthCache.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 8f9d3ec4847c4ac38bbf1038b528db87
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/codebase/SolanaMobileStack/MwaAuthCache/IMwaAuthCache.cs
+++ b/Runtime/codebase/SolanaMobileStack/MwaAuthCache/IMwaAuthCache.cs
@@ -1,0 +1,47 @@
+using System.Threading.Tasks;
+
+// ReSharper disable once CheckNamespace
+namespace Solana.Unity.SDK
+{
+    /// <summary>
+    /// Where the Mobile Wallet Adapter auth token gets stored.
+    ///
+    /// By default the SDK uses <see cref="PlayerPrefsAuthCache"/>, which
+    /// writes the token into <see cref="UnityEngine.PlayerPrefs"/>. That is
+    /// fine for most games but PlayerPrefs is plaintext on Android, so games
+    /// that hold real on-chain value should plug in a custom implementation
+    /// backed by Android Keystore / EncryptedSharedPreferences (or iOS
+    /// Keychain in the future).
+    ///
+    /// We only persist the auth token here. The public key is not a secret,
+    /// so it stays in PlayerPrefs and is out of scope for this interface.
+    ///
+    /// Implementations should keep all three methods cheap. <see cref="Clear"/>
+    /// is awaited synchronously from <c>Logout()</c>, so do not block on UI
+    /// or network calls inside it.
+    /// </summary>
+    public interface IMwaAuthCache
+    {
+        /// <summary>
+        /// Returns the stored auth token, or <c>null</c> if nothing is stored
+        /// yet. Return <c>null</c> (not an empty string) on a fresh install,
+        /// otherwise the SDK cannot tell "never logged in" from "logged in
+        /// with empty token".
+        /// </summary>
+        Task<string> Get();
+
+        /// <summary>
+        /// Persists <paramref name="authToken"/>. Treat <c>null</c> or empty
+        /// input as a no-op so a stale callsite cannot wipe a valid session
+        /// by accident.
+        /// </summary>
+        Task Set(string authToken);
+
+        /// <summary>
+        /// Removes the stored token. Must be idempotent so calling it twice
+        /// (e.g. <c>Logout()</c> followed by <c>DisconnectWallet()</c>) does
+        /// not throw.
+        /// </summary>
+        Task Clear();
+    }
+}

--- a/Runtime/codebase/SolanaMobileStack/MwaAuthCache/IMwaAuthCache.cs.meta
+++ b/Runtime/codebase/SolanaMobileStack/MwaAuthCache/IMwaAuthCache.cs.meta
@@ -1,11 +1,2 @@
 fileFormatVersion: 2
 guid: ca5f4c5739bd4f17bcff53c5d3aa344e
-MonoImporter:
-  externalObjects: {}
-  serializedVersion: 2
-  defaultReferences: []
-  executionOrder: 0
-  icon: {instanceID: 0}
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 

--- a/Runtime/codebase/SolanaMobileStack/MwaAuthCache/IMwaAuthCache.cs.meta
+++ b/Runtime/codebase/SolanaMobileStack/MwaAuthCache/IMwaAuthCache.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: ca5f4c5739bd4f17bcff53c5d3aa344e
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/codebase/SolanaMobileStack/MwaAuthCache/PlayerPrefsAuthCache.cs
+++ b/Runtime/codebase/SolanaMobileStack/MwaAuthCache/PlayerPrefsAuthCache.cs
@@ -1,0 +1,85 @@
+using System.Threading.Tasks;
+using UnityEngine;
+using UnityEngine.Scripting;
+
+// ReSharper disable once CheckNamespace
+namespace Solana.Unity.SDK
+{
+    /// <summary>
+    /// Default <see cref="IMwaAuthCache"/>, backed by
+    /// <see cref="PlayerPrefs"/>. Uses the same storage key
+    /// (<see cref="DefaultKey"/>) the SDK has been writing since PR #269,
+    /// so anyone who already has a cached session keeps it after upgrading.
+    /// No migration step needed.
+    ///
+    /// PlayerPrefs is plaintext on Android. Fine for hobby games and demos,
+    /// not fine for games that hold real assets - swap this out for a
+    /// custom <see cref="IMwaAuthCache"/> backed by Android Keystore or
+    /// EncryptedSharedPreferences in that case.
+    ///
+    /// The optional <paramref name="scope"/> on the second constructor lets
+    /// a single app keep independent sessions per wallet identity, e.g.
+    /// <c>new PlayerPrefsAuthCache("phantom")</c> writes to
+    /// <c>solana_sdk.mwa.auth_token.phantom</c>. Default (no scope) is
+    /// backward compatible with existing installs.
+    /// </summary>
+    [Preserve]
+    public class PlayerPrefsAuthCache : IMwaAuthCache
+    {
+        /// <summary>
+        /// Storage key used when no scope is supplied. Public so other
+        /// <see cref="IMwaAuthCache"/> implementations can reference the
+        /// same key for a one-time copy-up migration if they want to inherit
+        /// the existing PlayerPrefs session on first run.
+        /// </summary>
+        public const string DefaultKey = "solana_sdk.mwa.auth_token";
+
+        private readonly string _key;
+
+        /// <summary>
+        /// Creates the default unscoped cache. Equivalent to
+        /// <c>new PlayerPrefsAuthCache(null)</c>.
+        /// </summary>
+        public PlayerPrefsAuthCache() : this(null) { }
+
+        /// <summary>
+        /// Creates a cache that namespaces its storage under
+        /// <c>{DefaultKey}.{scope}</c>. If <paramref name="scope"/> is null
+        /// or empty the default key is used, which keeps backward
+        /// compatibility with installs created before scoping existed.
+        /// </summary>
+        public PlayerPrefsAuthCache(string scope)
+        {
+            _key = string.IsNullOrEmpty(scope)
+                ? DefaultKey
+                : DefaultKey + "." + scope;
+        }
+
+        /// <inheritdoc />
+        public Task<string> Get()
+        {
+            string value = PlayerPrefs.GetString(_key, null);
+            return Task.FromResult(string.IsNullOrEmpty(value) ? null : value);
+        }
+
+        /// <inheritdoc />
+        public Task Set(string authToken)
+        {
+            if (string.IsNullOrEmpty(authToken))
+            {
+                return Task.CompletedTask;
+            }
+            PlayerPrefs.SetString(_key, authToken);
+            PlayerPrefs.Save();
+            return Task.CompletedTask;
+        }
+
+        /// <inheritdoc />
+        public Task Clear()
+        {
+            PlayerPrefs.DeleteKey(_key);
+            PlayerPrefs.Save();
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/Runtime/codebase/SolanaMobileStack/MwaAuthCache/PlayerPrefsAuthCache.cs.meta
+++ b/Runtime/codebase/SolanaMobileStack/MwaAuthCache/PlayerPrefsAuthCache.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: eebeb7debb0f4617a37c2ff81316f2d9
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/codebase/SolanaMobileStack/MwaAuthCache/PlayerPrefsAuthCache.cs.meta
+++ b/Runtime/codebase/SolanaMobileStack/MwaAuthCache/PlayerPrefsAuthCache.cs.meta
@@ -1,11 +1,2 @@
 fileFormatVersion: 2
 guid: eebeb7debb0f4617a37c2ff81316f2d9
-MonoImporter:
-  externalObjects: {}
-  serializedVersion: 2
-  defaultReferences: []
-  executionOrder: 0
-  icon: {instanceID: 0}
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 

--- a/Runtime/codebase/SolanaMobileStack/MwaNativeChooser.cs
+++ b/Runtime/codebase/SolanaMobileStack/MwaNativeChooser.cs
@@ -1,0 +1,34 @@
+using UnityEngine;
+
+// ReSharper disable once CheckNamespace
+
+namespace Solana.Unity.SDK
+{
+    //C# bridge to MwaChooserHelper for chooser launch + package capture
+    internal static class MwaNativeChooser
+    {
+        private const string HelperClass = "com.solana.unity.mwa.MwaChooserHelper";
+
+        public static void LaunchWithChooser(AndroidJavaObject activity, AndroidJavaObject intent, string title)
+        {
+            using var helper = new AndroidJavaClass(HelperClass);
+            helper.CallStatic("launchWithChooser", activity, intent, title);
+        }
+
+        // last chosen package, null if unavailable
+        public static string ConsumeChosenPackage()
+        {
+            if (Application.platform != RuntimePlatform.Android){
+                return null;
+            }
+            try {
+                using var helper = new AndroidJavaClass(HelperClass);
+                return helper.CallStatic<string>("consumeChosenPackage");
+            }
+            catch (System.Exception e) {
+                Debug.LogWarning($"[MWA][Chooser] consumeChosenPackage failed: {e.Message}");
+                return null;
+            }
+        }
+    }
+}

--- a/Runtime/codebase/SolanaMobileStack/MwaNativeChooser.cs.meta
+++ b/Runtime/codebase/SolanaMobileStack/MwaNativeChooser.cs.meta
@@ -1,2 +1,11 @@
 fileFormatVersion: 2
 guid: 753f79c28711a2d48b8472c12ed83192
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/codebase/SolanaMobileStack/MwaNativeChooser.cs.meta
+++ b/Runtime/codebase/SolanaMobileStack/MwaNativeChooser.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 753f79c28711a2d48b8472c12ed83192

--- a/Runtime/codebase/SolanaMobileStack/MwaWalletDiscovery.cs
+++ b/Runtime/codebase/SolanaMobileStack/MwaWalletDiscovery.cs
@@ -25,7 +25,16 @@ namespace Solana.Unity.SDK
             if (cache == null)
                 return null;
 
-            var cached = await cache.GetSelectedWalletPackage();
+            string cached;
+            try
+            {
+                cached = await cache.GetSelectedWalletPackage();
+            }
+            catch (System.Exception e)
+            {
+                Debug.LogWarning($"[MWA][Discovery] Failed to read cached wallet package: {e.Message}. Falling back to chooser.");
+                return null;
+            }
             if (!string.IsNullOrEmpty(cached))
             {
                 Debug.Log($"[MWA][Discovery] Using cached wallet: {cached}");

--- a/Runtime/codebase/SolanaMobileStack/MwaWalletDiscovery.cs
+++ b/Runtime/codebase/SolanaMobileStack/MwaWalletDiscovery.cs
@@ -77,6 +77,7 @@ namespace Solana.Unity.SDK
                 return cached;
             }
 
+            Debug.Log("[MWA][Discovery] No cached wallet package; intent will be untargeted (OS chooser).");
             return null;
         }
     }

--- a/Runtime/codebase/SolanaMobileStack/MwaWalletDiscovery.cs
+++ b/Runtime/codebase/SolanaMobileStack/MwaWalletDiscovery.cs
@@ -1,0 +1,83 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using UnityEngine;
+
+// ReSharper disable once CheckNamespace
+
+namespace Solana.Unity.SDK
+{
+    /// <summary>
+    /// Resolves which installed wallet to target for MWA association.
+    /// </summary>
+    /// <remarks>
+    /// The SDK stays platform-agnostic, so it does NOT query the Android
+    /// PackageManager for installed wallets — that would require a
+    /// <c>&lt;queries&gt;</c> declaration in the consuming app's manifest, which
+    /// the SDK has no business shipping. Instead: the first association fires an
+    /// untargeted intent and lets the OS show its wallet chooser; the chosen
+    /// wallet is then identified from the authorization's account label
+    /// (<see cref="ResolvePackageFromLabel"/>) and cached, so subsequent
+    /// associations can target it directly.
+    /// </remarks>
+    public static class MwaWalletDiscovery
+    {
+        /// <summary>
+        /// Known mapping of MWA account labels to Android package names.
+        /// Used to identify the wallet after a successful authorization.
+        /// </summary>
+        private static readonly Dictionary<string, string> KnownWalletPackages = new(StringComparer.OrdinalIgnoreCase)
+        {
+            { "phantom-wallet", "app.phantom" },
+            { "phantom", "app.phantom" },
+            { "solflare", "com.solflare.mobile" },
+            { "backpack", "app.backpack" },
+            { "jupiter", "ag.jup.jupiter.android" },
+            { "jupiter-wallet", "ag.jup.jupiter.android" },
+            { "glow", "com.luma.wallet.prod" },
+            { "ultimate", "com.aspect.ultimate" },
+            { "tiplink", "xyz.tiplink.wallet" },
+        };
+
+        /// <summary>
+        /// Attempts to map an MWA account label (from
+        /// <see cref="AuthorizationResult.AccountLabel"/>) to an Android package
+        /// name using the known-wallets table. Returns <c>null</c> for
+        /// unrecognised labels.
+        /// </summary>
+        public static string ResolvePackageFromLabel(string accountLabel)
+        {
+            if (string.IsNullOrEmpty(accountLabel))
+                return null;
+
+            if (KnownWalletPackages.TryGetValue(accountLabel, out var package))
+            {
+                Debug.Log($"[MWA][Discovery] Mapped label \"{accountLabel}\" → {package}");
+                return package;
+            }
+
+            Debug.Log($"[MWA][Discovery] Unknown wallet label: \"{accountLabel}\"");
+            return null;
+        }
+
+        /// <summary>
+        /// Returns the cached wallet package to target, or <c>null</c> when none
+        /// is cached — in which case the caller should fire an untargeted intent
+        /// so the OS shows its wallet chooser.
+        /// </summary>
+        public static async Task<string> ResolveWalletPackage(IMwaWalletSelectionCache cache)
+        {
+            if (cache == null)
+                return null;
+
+            var cached = await cache.GetSelectedWalletPackage();
+            if (!string.IsNullOrEmpty(cached))
+            {
+                Debug.Log($"[MWA][Discovery] Using cached wallet: {cached}");
+                return cached;
+            }
+
+            return null;
+        }
+    }
+}

--- a/Runtime/codebase/SolanaMobileStack/MwaWalletDiscovery.cs
+++ b/Runtime/codebase/SolanaMobileStack/MwaWalletDiscovery.cs
@@ -1,5 +1,7 @@
 using System;
 using System.Collections.Generic;
+using System.Text;
+using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using UnityEngine;
 
@@ -16,9 +18,9 @@ namespace Solana.Unity.SDK
     /// <c>&lt;queries&gt;</c> declaration in the consuming app's manifest, which
     /// the SDK has no business shipping. Instead: the first association fires an
     /// untargeted intent and lets the OS show its wallet chooser; the chosen
-    /// wallet is then identified from the authorization's account label
-    /// (<see cref="ResolvePackageFromLabel"/>) and cached, so subsequent
-    /// associations can target it directly.
+    /// wallet is then identified from the authorization — account label first,
+    /// then the auth-token type as a fallback (see <see cref="ResolvePackage"/>) —
+    /// and cached, so subsequent associations can target it directly.
     /// </remarks>
     public static class MwaWalletDiscovery
     {
@@ -28,16 +30,41 @@ namespace Solana.Unity.SDK
         /// </summary>
         private static readonly Dictionary<string, string> KnownWalletPackages = new(StringComparer.OrdinalIgnoreCase)
         {
-            { "phantom-wallet", "app.phantom" },
-            { "phantom", "app.phantom" },
-            { "solflare", "com.solflare.mobile" },
-            { "backpack", "app.backpack" },
-            { "jupiter", "ag.jup.jupiter.android" },
-            { "jupiter-wallet", "ag.jup.jupiter.android" },
-            { "glow", "com.luma.wallet.prod" },
-            { "ultimate", "com.aspect.ultimate" },
-            { "tiplink", "xyz.tiplink.wallet" },
+            { "Solana.Unity", "com.solanamobile.wallet"},       // Seeker wallet
+            { "phantom-wallet", "app.phantom" },                // Phantom
+            { "Main Wallet", "com.solflare.mobile" },           // Solflare
+            { "backpack", "app.backpack.mobile.standalone" },   // Backpack
+            { "jupiter-wallet", "ag.jup.jupiter.android" },     // Jupiter
+            { "mwallet", "com.solana.mwallet" },                // MWA mock wallet
         };
+        
+        /// <summary>
+        /// Fallback mapping of MWA auth-token <c>typ</c> to Android package name,
+        /// used when the account label does not resolve. The <c>typ</c> names the
+        /// auth backend, not the app, so it cannot distinguish wallets that share
+        /// one (e.g. the Seeker native wallet and the Solflare app both emit
+        /// <c>solflare-auth-token</c>). In practice the label resolves the Solflare
+        /// app (label "Main Wallet"), so this fallback handles the Seeker case,
+        /// where the label is the account's own name.
+        /// </summary>
+        private static readonly Dictionary<string, string> KnownAuthTokenTypes = new(StringComparer.OrdinalIgnoreCase)
+        {
+            { "solflare-auth-token", "com.solanamobile.wallet" }, // Seeker native wallet
+        };
+
+        /// <summary>
+        /// Resolves the wallet package after a successful authorization, trying the
+        /// account label first and falling back to the auth-token <c>typ</c>.
+        /// Returns <c>null</c> when neither resolves.
+        /// </summary>
+        public static string ResolvePackage(string accountLabel, string authToken)
+        {
+            var fromLabel = ResolvePackageFromLabel(accountLabel);
+            if (!string.IsNullOrEmpty(fromLabel))
+                return fromLabel;
+
+            return ResolvePackageFromAuthToken(authToken);
+        }
 
         /// <summary>
         /// Attempts to map an MWA account label (from
@@ -55,9 +82,63 @@ namespace Solana.Unity.SDK
                 Debug.Log($"[MWA][Discovery] Mapped label \"{accountLabel}\" → {package}");
                 return package;
             }
-
+            
             Debug.Log($"[MWA][Discovery] Unknown wallet label: \"{accountLabel}\"");
             return null;
+        }
+
+        /// <summary>
+        /// Attempts to map a wallet by the <c>typ</c> embedded in its auth_token.
+        /// Returns <c>null</c> when the type can't be read or isn't known.
+        /// </summary>
+        public static string ResolvePackageFromAuthToken(string authToken)
+        {
+            var type = ExtractAuthTokenType(authToken);
+            if (string.IsNullOrEmpty(type))
+            {
+                Debug.Log("[MWA][Discovery] No auth-token type could be read.");
+                return null;
+            }
+
+            if (KnownAuthTokenTypes.TryGetValue(type, out var package))
+            {
+                Debug.Log($"[MWA][Discovery] Mapped auth-token type \"{type}\" → {package}");
+                return package;
+            }
+
+            Debug.Log($"[MWA][Discovery] Unknown auth-token type: \"{type}\"");
+            return null;
+        }
+
+        /// <summary>
+        /// Reads the <c>typ</c> field from an MWA auth_token. The token is opaque
+        /// per the spec, but known wallets prefix it with a base64 JSON header that
+        /// contains <c>typ</c>. A 4-aligned leading slice (enough to cover the
+        /// header) is decoded so trailing signature bytes never affect parsing.
+        /// Returns <c>null</c> on any failure.
+        /// </summary>
+        private static string ExtractAuthTokenType(string authToken)
+        {
+            if (string.IsNullOrEmpty(authToken))
+                return null;
+
+            try
+            {
+                var normalized = authToken.Replace('-', '+').Replace('_', '/');
+                var take = Math.Min(normalized.Length, 256);
+                take -= take % 4;
+                if (take == 0)
+                    return null;
+
+                var bytes = Convert.FromBase64String(normalized.Substring(0, take));
+                var text = Encoding.UTF8.GetString(bytes);
+                var match = Regex.Match(text, "\"typ\"\\s*:\\s*\"([^\"]+)\"");
+                return match.Success ? match.Groups[1].Value : null;
+            }
+            catch
+            {
+                return null;
+            }
         }
 
         /// <summary>

--- a/Runtime/codebase/SolanaMobileStack/MwaWalletDiscovery.cs
+++ b/Runtime/codebase/SolanaMobileStack/MwaWalletDiscovery.cs
@@ -1,7 +1,3 @@
-using System;
-using System.Collections.Generic;
-using System.Text;
-using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using UnityEngine;
 
@@ -10,139 +6,15 @@ using UnityEngine;
 namespace Solana.Unity.SDK
 {
     /// <summary>
-    /// Resolves which installed wallet to target for MWA association.
+    /// Reads the cached wallet package for targeted MWA associations.
     /// </summary>
     /// <remarks>
-    /// The SDK stays platform-agnostic, so it does NOT query the Android
-    /// PackageManager for installed wallets — that would require a
-    /// <c>&lt;queries&gt;</c> declaration in the consuming app's manifest, which
-    /// the SDK has no business shipping. Instead: the first association fires an
-    /// untargeted intent and lets the OS show its wallet chooser; the chosen
-    /// wallet is then identified from the authorization — account label first,
-    /// then the auth-token type as a fallback (see <see cref="ResolvePackage"/>) —
-    /// and cached, so subsequent associations can target it directly.
+    /// On first connect the OS wallet chooser captures the package via
+    /// <see cref="MwaNativeChooser"/>; subsequent calls read it from
+    /// <see cref="IMwaWalletSelectionCache"/>.
     /// </remarks>
     public static class MwaWalletDiscovery
     {
-        /// <summary>
-        /// Known mapping of MWA account labels to Android package names.
-        /// Used to identify the wallet after a successful authorization.
-        /// </summary>
-        private static readonly Dictionary<string, string> KnownWalletPackages = new(StringComparer.OrdinalIgnoreCase)
-        {
-            { "Solana.Unity", "com.solanamobile.wallet"},       // Seeker wallet
-            { "phantom-wallet", "app.phantom" },                // Phantom
-            { "Main Wallet", "com.solflare.mobile" },           // Solflare
-            { "backpack", "app.backpack.mobile.standalone" },   // Backpack
-            { "jupiter-wallet", "ag.jup.jupiter.android" },     // Jupiter
-            { "mwallet", "com.solana.mwallet" },                // MWA mock wallet
-        };
-        
-        /// <summary>
-        /// Fallback mapping of MWA auth-token <c>typ</c> to Android package name,
-        /// used when the account label does not resolve. The <c>typ</c> names the
-        /// auth backend, not the app, so it cannot distinguish wallets that share
-        /// one (e.g. the Seeker native wallet and the Solflare app both emit
-        /// <c>solflare-auth-token</c>). In practice the label resolves the Solflare
-        /// app (label "Main Wallet"), so this fallback handles the Seeker case,
-        /// where the label is the account's own name.
-        /// </summary>
-        private static readonly Dictionary<string, string> KnownAuthTokenTypes = new(StringComparer.OrdinalIgnoreCase)
-        {
-            { "solflare-auth-token", "com.solanamobile.wallet" }, // Seeker native wallet
-        };
-
-        /// <summary>
-        /// Resolves the wallet package after a successful authorization, trying the
-        /// account label first and falling back to the auth-token <c>typ</c>.
-        /// Returns <c>null</c> when neither resolves.
-        /// </summary>
-        public static string ResolvePackage(string accountLabel, string authToken)
-        {
-            var fromLabel = ResolvePackageFromLabel(accountLabel);
-            if (!string.IsNullOrEmpty(fromLabel))
-                return fromLabel;
-
-            return ResolvePackageFromAuthToken(authToken);
-        }
-
-        /// <summary>
-        /// Attempts to map an MWA account label (from
-        /// <see cref="AuthorizationResult.AccountLabel"/>) to an Android package
-        /// name using the known-wallets table. Returns <c>null</c> for
-        /// unrecognised labels.
-        /// </summary>
-        public static string ResolvePackageFromLabel(string accountLabel)
-        {
-            if (string.IsNullOrEmpty(accountLabel))
-                return null;
-
-            if (KnownWalletPackages.TryGetValue(accountLabel, out var package))
-            {
-                Debug.Log($"[MWA][Discovery] Mapped label \"{accountLabel}\" → {package}");
-                return package;
-            }
-            
-            Debug.Log($"[MWA][Discovery] Unknown wallet label: \"{accountLabel}\"");
-            return null;
-        }
-
-        /// <summary>
-        /// Attempts to map a wallet by the <c>typ</c> embedded in its auth_token.
-        /// Returns <c>null</c> when the type can't be read or isn't known.
-        /// </summary>
-        public static string ResolvePackageFromAuthToken(string authToken)
-        {
-            var type = ExtractAuthTokenType(authToken);
-            if (string.IsNullOrEmpty(type))
-            {
-                Debug.Log("[MWA][Discovery] No auth-token type could be read.");
-                return null;
-            }
-
-            if (KnownAuthTokenTypes.TryGetValue(type, out var package))
-            {
-                Debug.Log($"[MWA][Discovery] Mapped auth-token type \"{type}\" → {package}");
-                return package;
-            }
-
-            Debug.Log($"[MWA][Discovery] Unknown auth-token type: \"{type}\"");
-            return null;
-        }
-
-        /// <summary>
-        /// Reads the <c>typ</c> field from an MWA auth_token. The token is opaque
-        /// per the spec, but known wallets prefix it with a base64 JSON header that
-        /// contains <c>typ</c>. A 4-aligned leading slice (enough to cover the
-        /// header) is decoded so trailing signature bytes never affect parsing.
-        /// Returns <c>null</c> on any failure.
-        /// </summary>
-        private static string ExtractAuthTokenType(string authToken)
-        {
-            if (string.IsNullOrEmpty(authToken))
-                return null;
-
-            try
-            {
-                var normalized = authToken.Replace('-', '+').Replace('_', '/');
-                var take = Math.Min(normalized.Length, 256);
-                take -= take % 4;
-                if (take == 0)
-                    return null;
-
-                var bytes = Convert.FromBase64String(normalized.Substring(0, take));
-                var text = Encoding.UTF8.GetString(bytes);
-                Debug.Log($"[MWA][Discovery] Auth token extrated text: {text}");
-                
-                var match = Regex.Match(text, "\"typ\"\\s*:\\s*\"([^\"]+)\"");
-                return match.Success ? match.Groups[1].Value : null;
-            }
-            catch
-            {
-                return null;
-            }
-        }
-
         /// <summary>
         /// Returns the cached wallet package to target, or <c>null</c> when none
         /// is cached — in which case the caller should fire an untargeted intent

--- a/Runtime/codebase/SolanaMobileStack/MwaWalletDiscovery.cs
+++ b/Runtime/codebase/SolanaMobileStack/MwaWalletDiscovery.cs
@@ -132,6 +132,8 @@ namespace Solana.Unity.SDK
 
                 var bytes = Convert.FromBase64String(normalized.Substring(0, take));
                 var text = Encoding.UTF8.GetString(bytes);
+                Debug.Log($"[MWA][Discovery] Auth token extrated text: {text}");
+                
                 var match = Regex.Match(text, "\"typ\"\\s*:\\s*\"([^\"]+)\"");
                 return match.Success ? match.Groups[1].Value : null;
             }

--- a/Runtime/codebase/SolanaMobileStack/MwaWalletDiscovery.cs.meta
+++ b/Runtime/codebase/SolanaMobileStack/MwaWalletDiscovery.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: ff652571bc42d2c45b43ed1baea8af4a
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/codebase/SolanaMobileStack/PlayerPrefsMwaWalletSelectionCache.cs
+++ b/Runtime/codebase/SolanaMobileStack/PlayerPrefsMwaWalletSelectionCache.cs
@@ -17,7 +17,10 @@ namespace Solana.Unity.SDK
 
         public Task<string> GetSelectedWalletPackage()
         {
-            return Task.FromResult(PlayerPrefs.GetString(_key, null));
+            var value = PlayerPrefs.GetString(_key, null);
+            Debug.Log($"[MWA][WalletCache] Read selected wallet: " +
+                      (string.IsNullOrEmpty(value) ? "<empty>" : value));
+            return Task.FromResult(value);
         }
 
         public Task SetSelectedWalletPackage(string packageName)

--- a/Runtime/codebase/SolanaMobileStack/PlayerPrefsMwaWalletSelectionCache.cs
+++ b/Runtime/codebase/SolanaMobileStack/PlayerPrefsMwaWalletSelectionCache.cs
@@ -1,0 +1,42 @@
+using System.Threading.Tasks;
+using UnityEngine;
+
+// ReSharper disable once CheckNamespace
+
+namespace Solana.Unity.SDK
+{
+    public class PlayerPrefsMwaWalletSelectionCache : IMwaWalletSelectionCache
+    {
+        public const string DefaultKey = "solana_sdk.mwa.wallet_package";
+        private readonly string _key;
+
+        public PlayerPrefsMwaWalletSelectionCache(string key = DefaultKey)
+        {
+            _key = key;
+        }
+
+        public Task<string> GetSelectedWalletPackage()
+        {
+            return Task.FromResult(PlayerPrefs.GetString(_key, null));
+        }
+
+        public Task SetSelectedWalletPackage(string packageName)
+        {
+            if (string.IsNullOrEmpty(packageName))
+                return Task.CompletedTask;
+
+            PlayerPrefs.SetString(_key, packageName);
+            PlayerPrefs.Save();
+            Debug.Log($"[MWA][WalletCache] Stored selected wallet: {packageName}");
+            return Task.CompletedTask;
+        }
+
+        public Task ClearSelectedWalletPackage()
+        {
+            PlayerPrefs.DeleteKey(_key);
+            PlayerPrefs.Save();
+            Debug.Log("[MWA][WalletCache] Cleared selected wallet");
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/Runtime/codebase/SolanaMobileStack/PlayerPrefsMwaWalletSelectionCache.cs
+++ b/Runtime/codebase/SolanaMobileStack/PlayerPrefsMwaWalletSelectionCache.cs
@@ -12,7 +12,7 @@ namespace Solana.Unity.SDK
 
         public PlayerPrefsMwaWalletSelectionCache(string key = DefaultKey)
         {
-            _key = key;
+            _key = string.IsNullOrEmpty(key) ? DefaultKey : key;
         }
 
         public Task<string> GetSelectedWalletPackage()

--- a/Runtime/codebase/SolanaMobileStack/PlayerPrefsMwaWalletSelectionCache.cs.meta
+++ b/Runtime/codebase/SolanaMobileStack/PlayerPrefsMwaWalletSelectionCache.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: ac39ed9d5aec8a24d88c71f6923abff0
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/codebase/SolanaMobileStack/SolanaMobileWalletAdapter.cs
+++ b/Runtime/codebase/SolanaMobileStack/SolanaMobileWalletAdapter.cs
@@ -267,7 +267,17 @@ namespace Solana.Unity.SDK
             PlayerPrefs.DeleteKey(PrefKeyPublicKey);
             PlayerPrefs.Save();
             _authToken = null;
-            _authCache.Clear().GetAwaiter().GetResult();
+            try
+            {
+                // Custom IMwaAuthCache impls (Keystore, EncryptedSharedPreferences, etc.) can
+                // throw on backend errors. Swallow here so DisconnectWallet still fires
+                // OnWalletDisconnected and the rest of the logout sequence completes.
+                _authCache.Clear().GetAwaiter().GetResult();
+            }
+            catch (Exception e)
+            {
+                Debug.LogWarning($"[MWA] Auth cache clear failed during Logout: {e}");
+            }
         }
 
         public async Task DisconnectWallet()

--- a/Runtime/codebase/SolanaMobileStack/SolanaMobileWalletAdapter.cs
+++ b/Runtime/codebase/SolanaMobileStack/SolanaMobileWalletAdapter.cs
@@ -26,7 +26,11 @@ namespace Solana.Unity.SDK
     public class SolanaMobileWalletAdapter : WalletBase
     {
         private const string PrefKeyPublicKey = "solana_sdk.mwa.public_key";
-        private const string PrefKeyAuthToken = "solana_sdk.mwa.auth_token";
+        // Single source of truth lives in PlayerPrefsAuthCache.DefaultKey.
+        // Kept here as a private alias because the legacy key migration
+        // below still touches PlayerPrefs directly. Live reads and writes
+        // for the auth token go through _authCache (see IMwaAuthCache).
+        private const string PrefKeyAuthToken = PlayerPrefsAuthCache.DefaultKey;
         
         private readonly SolanaMobileWalletAdapterOptions _walletOptions;
         
@@ -35,6 +39,7 @@ namespace Solana.Unity.SDK
         private TaskCompletionSource<Account> _loginTaskCompletionSource;
         private TaskCompletionSource<Transaction> _signedTransactionTaskCompletionSource;
         private readonly WalletBase _internalWallet;
+        private readonly IMwaAuthCache _authCache;
         private string _authToken;
 
         public event Action OnWalletDisconnected;
@@ -45,7 +50,8 @@ namespace Solana.Unity.SDK
             RpcCluster rpcCluster = RpcCluster.DevNet, 
             string customRpcUri = null, 
             string customStreamingRpcUri = null, 
-            bool autoConnectOnStartup = false) : base(rpcCluster, customRpcUri, customStreamingRpcUri, autoConnectOnStartup
+            bool autoConnectOnStartup = false,
+            IMwaAuthCache authCache = null) : base(rpcCluster, customRpcUri, customStreamingRpcUri, autoConnectOnStartup
         )
         {
             _walletOptions = solanaWalletOptions;
@@ -53,6 +59,7 @@ namespace Solana.Unity.SDK
             {
                 throw new Exception("SolanaMobileWalletAdapter can only be used on Android");
             }
+            _authCache = authCache ?? new PlayerPrefsAuthCache();
             MigrateLegacyPrefKeys();
         }
 
@@ -80,7 +87,7 @@ namespace Solana.Unity.SDK
             if (_walletOptions.keepConnectionAlive)
             {
                 string pk = PlayerPrefs.GetString(PrefKeyPublicKey, null);
-                string authToken = PlayerPrefs.GetString(PrefKeyAuthToken, null);
+                string authToken = await _authCache.Get();
                 if (!pk.IsNullOrEmpty() && !authToken.IsNullOrEmpty())
                 {
                     string reauthPublicKey = null;
@@ -114,16 +121,15 @@ namespace Solana.Unity.SDK
                         }
                         else
                         {
-                            PlayerPrefs.SetString(PrefKeyAuthToken, _authToken);
-                            PlayerPrefs.Save();
+                            await _authCache.Set(_authToken);
                             var resolvedKey = !string.IsNullOrEmpty(reauthPublicKey) ? reauthPublicKey : pk;
                             return new Account(string.Empty, new PublicKey(resolvedKey));
                         }
                     }
                     // Reauthorize failed or returned empty token - clear cached credentials
                     PlayerPrefs.DeleteKey(PrefKeyPublicKey);
-                    PlayerPrefs.DeleteKey(PrefKeyAuthToken);
                     PlayerPrefs.Save();
+                    await _authCache.Clear();
                 }
                 else if (!pk.IsNullOrEmpty())
                 {
@@ -162,8 +168,8 @@ namespace Solana.Unity.SDK
                 if (_walletOptions.keepConnectionAlive)
                 {
                     PlayerPrefs.SetString(PrefKeyPublicKey, publicKey.ToString());
-                    PlayerPrefs.SetString(PrefKeyAuthToken, _authToken);
                     PlayerPrefs.Save();
+                    await _authCache.Set(_authToken);
                 }
             }
             return new Account(string.Empty, publicKey);
@@ -179,7 +185,7 @@ namespace Solana.Unity.SDK
         protected override async Task<Transaction[]> _SignAllTransactions(Transaction[] transactions)
         {
             if (_authToken.IsNullOrEmpty() && _walletOptions.keepConnectionAlive)
-                _authToken = PlayerPrefs.GetString(PrefKeyAuthToken, null);
+                _authToken = await _authCache.Get();
 
             var cluster = RPCNameMap[(int)RpcCluster];
             SignedResult res = null;
@@ -229,28 +235,39 @@ namespace Solana.Unity.SDK
                 _authToken = authorization.AuthToken;
                 if (_walletOptions.keepConnectionAlive)
                 {
-                    PlayerPrefs.SetString(PrefKeyAuthToken, _authToken);
-                    PlayerPrefs.Save();
+                    await _authCache.Set(_authToken);
                 }
             }
             return res.SignedPayloads.Select(transaction => Transaction.Deserialize(transaction)).ToArray();
         }
 
 
+        /// <summary>
+        /// Clears the in-memory token, the cached public key in PlayerPrefs,
+        /// and the auth token stored in <see cref="IMwaAuthCache"/>. Does
+        /// NOT call <c>deauthorize</c> on the wallet side. Use
+        /// <see cref="DisconnectWallet"/> when the wallet-side session also
+        /// needs to be revoked.
+        ///
+        /// Stays synchronous to keep the <see cref="WalletBase"/> override
+        /// signature stable. The cache <see cref="IMwaAuthCache.Clear"/>
+        /// call is awaited synchronously, so custom cache impls must not
+        /// block on UI or network here.
+        /// </summary>
         public override void Logout()
         {
             base.Logout();
             PlayerPrefs.DeleteKey(PrefKeyPublicKey);
-            _authToken = null;
-            PlayerPrefs.DeleteKey(PrefKeyAuthToken);
             PlayerPrefs.Save();
+            _authToken = null;
+            _authCache.Clear().GetAwaiter().GetResult();
         }
 
         public async Task DisconnectWallet()
         {
             string authToken = _authToken;
             if (authToken.IsNullOrEmpty())
-                authToken = PlayerPrefs.GetString(PrefKeyAuthToken, null);
+                authToken = await _authCache.Get();
 
             if (!authToken.IsNullOrEmpty())
             {
@@ -333,7 +350,7 @@ namespace Solana.Unity.SDK
         public override async Task<byte[]> SignMessage(byte[] message)
         {
             if (_authToken.IsNullOrEmpty() && _walletOptions.keepConnectionAlive)
-                _authToken = PlayerPrefs.GetString(PrefKeyAuthToken, null);
+                _authToken = await _authCache.Get();
 
             string cachedPk = Account?.PublicKey?.ToString()
                 ?? PlayerPrefs.GetString(PrefKeyPublicKey, null);
@@ -391,8 +408,7 @@ namespace Solana.Unity.SDK
                 _authToken = authorization.AuthToken;
                 if (_walletOptions.keepConnectionAlive)
                 {
-                    PlayerPrefs.SetString(PrefKeyAuthToken, _authToken);
-                    PlayerPrefs.Save();
+                    await _authCache.Set(_authToken);
                 }
             }
             return signedMessages.SignedPayloadsBytes[0];

--- a/Runtime/codebase/SolanaMobileStack/SolanaMobileWalletAdapter.cs
+++ b/Runtime/codebase/SolanaMobileStack/SolanaMobileWalletAdapter.cs
@@ -126,13 +126,20 @@ namespace Solana.Unity.SDK
                             return new Account(string.Empty, new PublicKey(resolvedKey));
                         }
                     }
-                    // Reauthorize failed or returned empty token - clear cached credentials
+                    // Reauthorize failed or returned empty token - clear cached credentials.
+                    // Drop _authToken too; the reauthorize lambda may have populated it from
+                    // a stale wallet response, and leaving it set would push the next call
+                    // down the Reauthorize() branch with a token we already know is bad.
+                    _authToken = null;
                     PlayerPrefs.DeleteKey(PrefKeyPublicKey);
                     PlayerPrefs.Save();
                     await _authCache.Clear();
                 }
                 else if (!pk.IsNullOrEmpty())
                 {
+                    // Inconsistent state: pk persisted but no auth token. Wipe memory too
+                    // so a re-entrant Login on the same instance cannot reuse a stale token.
+                    _authToken = null;
                     PlayerPrefs.DeleteKey(PrefKeyPublicKey);
                     PlayerPrefs.Save();
                 }

--- a/Runtime/codebase/SolanaMobileStack/SolanaMobileWalletAdapter.cs
+++ b/Runtime/codebase/SolanaMobileStack/SolanaMobileWalletAdapter.cs
@@ -124,6 +124,8 @@ namespace Solana.Unity.SDK
         private async Task<LocalAssociationScenario> CreateTargetedScenario()
         {
             var package = await ResolveWalletPackage();
+            Debug.Log($"[MWA] Resolved target wallet package: " +
+                      (string.IsNullOrEmpty(package) ? "<none>" : package));
             return new LocalAssociationScenario(package);
         }
 
@@ -138,7 +140,10 @@ namespace Solana.Unity.SDK
 
             var existing = await _walletSelectionCache.GetSelectedWalletPackage();
             if (!string.IsNullOrEmpty(existing))
+            {
+                Debug.Log($"[MWA] TryCacheWalletPackage: keeping existing cached package '{existing}', skipping store of '{walletPackage}'");
                 return;
+            }
 
             await _walletSelectionCache.SetSelectedWalletPackage(walletPackage);
         }
@@ -273,8 +278,8 @@ namespace Solana.Unity.SDK
             // operation that actually needs the wallet (see RunPrivileged).
             if (_walletOptions.keepConnectionAlive)
             {
-                string pk = PlayerPrefs.GetString(PrefKeyPublicKey, null);
-                string authToken = await _authCache.Get();
+                var pk = PlayerPrefs.GetString(PrefKeyPublicKey, null);
+                var authToken = await _authCache.Get();
 
                 if (!pk.IsNullOrEmpty() && !authToken.IsNullOrEmpty())
                 {
@@ -321,11 +326,15 @@ namespace Solana.Unity.SDK
             PlayerPrefs.Save();
             await _authCache.Set(_authToken);
 
-            // Try to identify and cache the wallet package from the account label
-            // so subsequent connections can target it directly.
-            await TryCacheWalletPackage(
-                MwaWalletDiscovery.ResolvePackageFromLabel(
-                    authorizationOperation.Authorization.AccountLabel));
+            // Try to identify and cache the wallet package from the account label so subsequent connections can target it directly.
+            var rawLabel = authorizationOperation.Authorization.AccountLabel;
+            var resolvedFromLabel = MwaWalletDiscovery.ResolvePackageFromLabel(rawLabel);
+            Debug.Log($"[MWA] Login store path: AccountLabel=" +
+                      (string.IsNullOrEmpty(rawLabel) ? "<empty>" : $"\"{rawLabel}\"") +
+                      $" -> resolved package=" +
+                      (string.IsNullOrEmpty(resolvedFromLabel) ? "<none>" : resolvedFromLabel));
+            
+            await TryCacheWalletPackage(resolvedFromLabel);
 
             return new Account(string.Empty, publicKey);
         }
@@ -399,11 +408,18 @@ namespace Solana.Unity.SDK
             if (authToken.IsNullOrEmpty())
                 authToken = await _authCache.Get();
 
-            if (!authToken.IsNullOrEmpty())
+            // Deauthorize must go straight to the wallet that issued the token.
+            // If we can't resolve that exact package (none cached, or the wallet
+            // was uninstalled), do NOT fall back to an untargeted intent — that
+            // would pop the OS wallet chooser, which makes no sense for a
+            // disconnect. Skip the remote revoke and just clear local state.
+            string targetPackage = await ResolveWalletPackage();
+
+            if (!authToken.IsNullOrEmpty() && !string.IsNullOrEmpty(targetPackage))
             {
                 try
                 {
-                    using var localAssociationScenario = await CreateTargetedScenario();
+                    using var localAssociationScenario = new LocalAssociationScenario(targetPackage);
                     var result = await localAssociationScenario.StartAndExecute(
                         new List<Action<IAdapterOperations>>
                         {
@@ -422,6 +438,12 @@ namespace Solana.Unity.SDK
                 {
                     Debug.LogWarning($"[MWA] Deauthorize transport failed (best-effort): {e}");
                 }
+            }
+            else
+            {
+                Debug.Log("[MWA] DisconnectWallet: no targetable wallet package " +
+                          "(none cached or token already gone); skipping remote deauthorize, " +
+                          "clearing local session only.");
             }
 
             Logout();

--- a/Runtime/codebase/SolanaMobileStack/SolanaMobileWalletAdapter.cs
+++ b/Runtime/codebase/SolanaMobileStack/SolanaMobileWalletAdapter.cs
@@ -326,15 +326,24 @@ namespace Solana.Unity.SDK
             PlayerPrefs.Save();
             await _authCache.Set(_authToken);
 
-            // Identify and cache the wallet package so subsequent connections can
-            // target it directly: try the account label first, then fall back to
-            // the auth-token type.
+            //Cache wallet package = chooser pick first, else label/token fallback
             var rawLabel = authorizationOperation.Authorization.AccountLabel;
-            var resolvedPackage = MwaWalletDiscovery.ResolvePackage(rawLabel, _authToken);
-            Debug.Log($"[MWA] Login store path: AccountLabel=" +
-                      (string.IsNullOrEmpty(rawLabel) ? "<empty>" : $"\"{rawLabel}\"") +
-                      $" -> resolved package=" +
-                      (string.IsNullOrEmpty(resolvedPackage) ? "<none>" : resolvedPackage));
+            var chosenPackage = MwaNativeChooser.ConsumeChosenPackage();
+            string resolvedPackage;
+            if (!string.IsNullOrEmpty(chosenPackage))
+            {
+                resolvedPackage = chosenPackage;
+                Debug.Log($"[MWA] Login store path: chooser-selected package={chosenPackage}" +
+                          (string.IsNullOrEmpty(rawLabel) ? "" : $" (label=\"{rawLabel}\")"));
+            }
+            else
+            {
+                resolvedPackage = MwaWalletDiscovery.ResolvePackage(rawLabel, _authToken);
+                Debug.Log($"[MWA] Login store path: AccountLabel=" +
+                          (string.IsNullOrEmpty(rawLabel) ? "<empty>" : $"\"{rawLabel}\"") +
+                          $" -> resolved package=" +
+                          (string.IsNullOrEmpty(resolvedPackage) ? "<none>" : resolvedPackage));
+            }
 
             await TryCacheWalletPackage(resolvedPackage);
 

--- a/Runtime/codebase/SolanaMobileStack/SolanaMobileWalletAdapter.cs
+++ b/Runtime/codebase/SolanaMobileStack/SolanaMobileWalletAdapter.cs
@@ -3,6 +3,7 @@ using System.Linq;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using Solana.Unity.Rpc.Models;
+using Solana.Unity.SDK;
 using Solana.Unity.Wallet;
 using UnityEngine;
 using WebSocketSharp;
@@ -43,14 +44,16 @@ namespace Solana.Unity.SDK
         private const string PrefKeyAuthToken = PlayerPrefsAuthCache.DefaultKey;
         
         private readonly SolanaMobileWalletAdapterOptions _walletOptions;
-        
+
         private Transaction _currentTransaction;
 
         private TaskCompletionSource<Account> _loginTaskCompletionSource;
         private TaskCompletionSource<Transaction> _signedTransactionTaskCompletionSource;
         private readonly WalletBase _internalWallet;
         private readonly IMwaAuthCache _authCache;
+        private readonly IMwaWalletSelectionCache _walletSelectionCache;
         private string _authToken;
+        private bool _loginInProgress;
         private static MobileWalletAdapterLifecycleHook _lifecycleHook;
 
         public event Action OnWalletDisconnected;
@@ -58,11 +61,12 @@ namespace Solana.Unity.SDK
 
         public SolanaMobileWalletAdapter(
             SolanaMobileWalletAdapterOptions solanaWalletOptions,
-            RpcCluster rpcCluster = RpcCluster.DevNet, 
-            string customRpcUri = null, 
-            string customStreamingRpcUri = null, 
+            RpcCluster rpcCluster = RpcCluster.DevNet,
+            string customRpcUri = null,
+            string customStreamingRpcUri = null,
             bool autoConnectOnStartup = false,
-            IMwaAuthCache authCache = null) : base(rpcCluster, customRpcUri, customStreamingRpcUri, autoConnectOnStartup
+            IMwaAuthCache authCache = null,
+            IMwaWalletSelectionCache walletSelectionCache = null) : base(rpcCluster, customRpcUri, customStreamingRpcUri, autoConnectOnStartup
         )
         {
             _walletOptions = solanaWalletOptions;
@@ -71,6 +75,7 @@ namespace Solana.Unity.SDK
                 throw new Exception("SolanaMobileWalletAdapter can only be used on Android");
             }
             _authCache = authCache ?? new PlayerPrefsAuthCache();
+            _walletSelectionCache = walletSelectionCache ?? new PlayerPrefsMwaWalletSelectionCache();
             MigrateLegacyPrefKeys();
             EnsureLifecycleHook();
             _lifecycleHook.ApplicationFocusChanged -= OnApplicationFocusChanged;
@@ -102,6 +107,131 @@ namespace Solana.Unity.SDK
             }
         }
 
+        /// <summary>
+        /// Resolves the target wallet package via cache → discovery → native picker.
+        /// Returns the package name to target, or null if no wallet was found/selected.
+        /// </summary>
+        private async Task<string> ResolveWalletPackage()
+        {
+            return await MwaWalletDiscovery.ResolveWalletPackage(_walletSelectionCache);
+        }
+
+        /// <summary>
+        /// Creates a <see cref="LocalAssociationScenario"/> targeting the resolved
+        /// wallet package. On first use this may show a native picker if multiple
+        /// wallets are installed; subsequent calls use the cached selection.
+        /// </summary>
+        private async Task<LocalAssociationScenario> CreateTargetedScenario()
+        {
+            var package = await ResolveWalletPackage();
+            return new LocalAssociationScenario(package);
+        }
+
+        /// <summary>
+        /// Caches the wallet package name identified during the WebSocket
+        /// session so subsequent connections can target it directly.
+        /// </summary>
+        private async Task TryCacheWalletPackage(string walletPackage)
+        {
+            if (string.IsNullOrEmpty(walletPackage))
+                return;
+
+            var existing = await _walletSelectionCache.GetSelectedWalletPackage();
+            if (!string.IsNullOrEmpty(existing))
+                return;
+
+            await _walletSelectionCache.SetSelectedWalletPackage(walletPackage);
+        }
+
+        /// <summary>
+        /// Runs a privileged operation (sign transactions / sign messages) against
+        /// the targeted wallet, re-using the cached auth token when possible so the
+        /// wallet only ever surfaces for the operation itself — never for a
+        /// standalone (re)authorization.
+        /// </summary>
+        /// <remarks>
+        /// Honors the "no wallet popups unless necessary" rule. Phantom rejects a
+        /// bare <c>sign_transactions</c> ("auth_token not valid for signing"), so a
+        /// session must be (re)authorized before the operation. We do that in the
+        /// SAME session as the operation, so the wallet surfaces once:
+        /// <list type="bullet">
+        /// <item>Token present → [reauthorize, op]. With a valid token reauthorize
+        /// is silent (≈250 ms, no prompt); only the operation's own prompt shows.</item>
+        /// <item>Reauthorize rejected (token expired/revoked) → [authorize, op].</item>
+        /// <item>No token → [authorize, op].</item>
+        /// </list>
+        /// Do NOT precede this with an un-authorized "direct" attempt: a rejected
+        /// bare sign knocks Phantom out of its authorized state and forces the
+        /// following reauthorize to prompt.
+        /// </remarks>
+        private async Task RunPrivileged(Action<IAdapterOperations> privilegedAction, string label)
+        {
+            if (_authToken.IsNullOrEmpty() && _walletOptions.keepConnectionAlive)
+                _authToken = await _authCache.Get();
+
+            // Token present: reauthorize (silent when the token is valid) and run the
+            // operation in one session, so only the operation itself prompts.
+            if (!_authToken.IsNullOrEmpty())
+            {
+                var reauthorize = new ReauthorizeOperation(_walletOptions, _authToken);
+                using (var scenario = await CreateTargetedScenario())
+                {
+                    var actions = reauthorize.BuildActions();
+                    actions.Add(privilegedAction);
+                    var result = await scenario.StartAndExecute(actions);
+                    if (result.WasSuccessful)
+                    {
+                        await PersistRefreshedToken(reauthorize.Authorization);
+                        return;
+                    }
+
+                    // Reauthorize succeeded but the operation failed (e.g. the user
+                    // declined): surface as-is rather than re-prompting with authorize.
+                    if (reauthorize.Authorization != null)
+                    {
+                        Debug.LogError($"[MWA] {label} failed: {result.Error?.Message}");
+                        throw new Exception(result.Error?.Message ?? $"[MWA] {label} failed");
+                    }
+
+                    // Token expired/revoked — a fresh authorization is now necessary.
+                    Debug.LogWarning($"[MWA] {label}: cached token rejected, re-authorizing");
+                    _authToken = null;
+                }
+            }
+
+            // No usable token: authorize (prompts) and run the operation in one session.
+            var authorize = new AuthorizeOperation(_walletOptions, RPCNameMap[(int)RpcCluster]);
+            using (var scenario = await CreateTargetedScenario())
+            {
+                var actions = authorize.BuildActions();
+                actions.Add(privilegedAction);
+                var authResult = await scenario.StartAndExecute(actions);
+                if (!authResult.WasSuccessful)
+                {
+                    Debug.LogError($"[MWA] {label} failed: {authResult.Error?.Message}");
+                    throw new Exception(authResult.Error?.Message ?? $"[MWA] {label} failed");
+                }
+                if (authorize.Authorization == null)
+                    throw new Exception($"[MWA] {label}: authorization was not populated");
+
+                await PersistRefreshedToken(authorize.Authorization);
+            }
+        }
+
+        /// <summary>
+        /// Persists a refreshed auth token returned by authorize/reauthorize.
+        /// No-op when the wallet returned no token or connection caching is off.
+        /// </summary>
+        private async Task PersistRefreshedToken(AuthorizationResult authorization)
+        {
+            if (authorization == null || string.IsNullOrEmpty(authorization.AuthToken))
+                return;
+
+            _authToken = authorization.AuthToken;
+            if (_walletOptions.keepConnectionAlive)
+                await _authCache.Set(_authToken);
+        }
+
         private static void MigrateLegacyPrefKeys()
         {
             const string legacyPk = "pk";
@@ -123,101 +253,80 @@ namespace Solana.Unity.SDK
 
         protected override async Task<Account> _Login(string password = null)
         {
+            _loginInProgress = true;
+            try
+            {
+                return await _LoginInternal(password);
+            }
+            finally
+            {
+                _loginInProgress = false;
+            }
+        }
+
+        private async Task<Account> _LoginInternal(string password = null)
+        {
+            // Fast path: if we have cached credentials, return immediately without
+            // opening the wallet. We deliberately do NOT reauthorize here — a
+            // standalone reauthorize would briefly surface the wallet for no
+            // user-visible reason. Token validity is re-checked lazily on the next
+            // operation that actually needs the wallet (see RunPrivileged).
             if (_walletOptions.keepConnectionAlive)
             {
                 string pk = PlayerPrefs.GetString(PrefKeyPublicKey, null);
                 string authToken = await _authCache.Get();
+
                 if (!pk.IsNullOrEmpty() && !authToken.IsNullOrEmpty())
                 {
-                    string reauthPublicKey = null;
-                    // TODO: change to using var after PR #260 merges (IDisposable not yet on LocalAssociationScenario)
-                    var reauthorizeScenario = new LocalAssociationScenario();
-                    var reauthorizeResult = await reauthorizeScenario.StartAndExecute(
-                        new List<Action<IAdapterOperations>>
-                        {
-                            async client =>
-                            {
-                                var reauth = await client.Reauthorize(
-                                    new Uri(_walletOptions.identityUri),
-                                    new Uri(_walletOptions.iconUri, UriKind.Relative),
-                                    _walletOptions.name, authToken);
-                                if (reauth != null && !string.IsNullOrEmpty(reauth.AuthToken))
-                                {
-                                    _authToken = reauth.AuthToken;
-                                    reauthPublicKey = reauth.PublicKey != null
-                                        ? new PublicKey(reauth.PublicKey).ToString()
-                                        : null;
-                                }
-                            }
-                        }
-                    );
-                    if (reauthorizeResult.WasSuccessful)
-                    {
-                        if (string.IsNullOrEmpty(_authToken))
-                        {
-                            // Reauthorize RPC succeeded but wallet returned no token - treat as failure
-                            // Fall through to cleanup below
-                        }
-                        else
-                        {
-                            await _authCache.Set(_authToken);
-                            var resolvedKey = !string.IsNullOrEmpty(reauthPublicKey) ? reauthPublicKey : pk;
-                            return new Account(string.Empty, new PublicKey(resolvedKey));
-                        }
-                    }
-                    // Reauthorize failed or returned empty token - clear cached credentials.
-                    // Drop _authToken too; the reauthorize lambda may have populated it from
-                    // a stale wallet response, and leaving it set would push the next call
-                    // down the Reauthorize() branch with a token we already know is bad.
-                    _authToken = null;
-                    PlayerPrefs.DeleteKey(PrefKeyPublicKey);
-                    PlayerPrefs.Save();
-                    await _authCache.Clear();
+                    _authToken = authToken;
+                    return new Account(string.Empty, new PublicKey(pk));
                 }
-                else if (!pk.IsNullOrEmpty())
+
+                if (!pk.IsNullOrEmpty())
                 {
-                    // Inconsistent state: pk persisted but no auth token. Wipe memory too
-                    // so a re-entrant Login on the same instance cannot reuse a stale token.
+                    // Inconsistent state: pk persisted but no auth token. Wipe
+                    // so a re-entrant Login on the same instance cannot reuse stale data.
                     _authToken = null;
                     PlayerPrefs.DeleteKey(PrefKeyPublicKey);
                     PlayerPrefs.Save();
                 }
             }
-            AuthorizationResult authorization = null;
-            var localAssociationScenario = new LocalAssociationScenario();
+
+            using var localAssociationScenario = await CreateTargetedScenario();
+
             var cluster = RPCNameMap[(int)RpcCluster];
-            var result = await localAssociationScenario.StartAndExecute(
-                new List<Action<IAdapterOperations>>
-                {
-                    async client =>
-                    {
-                        authorization = await client.Authorize(
-                            new Uri(_walletOptions.identityUri),
-                            new Uri(_walletOptions.iconUri, UriKind.Relative),
-                            _walletOptions.name, cluster);
-                    }
-                }
-            );
+            var authorizationOperation = new AuthorizeOperation(_walletOptions, cluster);
+            
+            var result = await localAssociationScenario.StartAndExecute(authorizationOperation.BuildActions());
             if (!result.WasSuccessful)
             {
                 Debug.LogError(result.Error.Message);
                 throw new Exception(result.Error.Message);
             }
-            if (authorization == null)
+            
+            if (authorizationOperation.Authorization == null)
             {
                 throw new Exception("[MWA] Login: authorization was not populated");
             }
-            var publicKey = new PublicKey(authorization.PublicKey);
-            if (!string.IsNullOrEmpty(authorization.AuthToken))
-            {
-                _authToken = authorization.AuthToken;
-                if (_walletOptions.keepConnectionAlive)
-                {
-                    PlayerPrefs.SetString(PrefKeyPublicKey, publicKey.ToString());
-                    PlayerPrefs.Save();
-                    await _authCache.Set(_authToken);
-                }
-            }
+            
+            var publicKey = new PublicKey(authorizationOperation.Authorization.PublicKey);
+            if (string.IsNullOrEmpty(authorizationOperation.Authorization.AuthToken))
+                return new Account(string.Empty, publicKey);
+
+            _authToken = authorizationOperation.Authorization.AuthToken;
+            if (!_walletOptions.keepConnectionAlive)
+                return new Account(string.Empty, publicKey);
+
+            PlayerPrefs.SetString(PrefKeyPublicKey, publicKey.ToString());
+            PlayerPrefs.Save();
+            await _authCache.Set(_authToken);
+
+            // Try to identify and cache the wallet package from the account label
+            // so subsequent connections can target it directly.
+            await TryCacheWalletPackage(
+                MwaWalletDiscovery.ResolvePackageFromLabel(
+                    authorizationOperation.Authorization.AccountLabel));
+
             return new Account(string.Empty, publicKey);
         }
 
@@ -227,64 +336,20 @@ namespace Solana.Unity.SDK
             return result[0];
         }
 
-
         protected override async Task<Transaction[]> _SignAllTransactions(Transaction[] transactions)
         {
-            if (_authToken.IsNullOrEmpty() && _walletOptions.keepConnectionAlive)
-                _authToken = await _authCache.Get();
-
-            var cluster = RPCNameMap[(int)RpcCluster];
             SignedResult res = null;
-            var localAssociationScenario = new LocalAssociationScenario();
-            AuthorizationResult authorization = null;
-            var result = await localAssociationScenario.StartAndExecute(
-                new List<Action<IAdapterOperations>>
-                {
-                    async client =>
-                    {
-                        if (_authToken.IsNullOrEmpty())
-                        {
-                            authorization = await client.Authorize(
-                                new Uri(_walletOptions.identityUri),
-                                new Uri(_walletOptions.iconUri, UriKind.Relative),
-                                _walletOptions.name, cluster);
-                        }
-                        else
-                        {
-                            authorization = await client.Reauthorize(
-                                new Uri(_walletOptions.identityUri),
-                                new Uri(_walletOptions.iconUri, UriKind.Relative),
-                                _walletOptions.name, _authToken);   
-                        }
-                    },
-                    async client =>
-                    {
-                        res = await client.SignTransactions(transactions.Select(transaction => transaction.Serialize()).ToList());
-                    }
-                }
-            );
-            if (!result.WasSuccessful)
+            await RunPrivileged(async client =>
             {
-                Debug.LogError(result.Error.Message);
-                throw new Exception(result.Error.Message);
-            }
-            if (authorization == null)
-            {
-                throw new Exception("[MWA] SignAllTransactions: authorization was not populated");
-            }
+                res = await client.SignTransactions(
+                    transactions.Select(t => t.Serialize()).ToList());
+            }, "SignAllTransactions");
+
             if (res == null)
-            {
                 throw new Exception("[MWA] SignAllTransactions: signed payloads were not populated");
-            }
-            if (!string.IsNullOrEmpty(authorization.AuthToken))
-            {
-                _authToken = authorization.AuthToken;
-                if (_walletOptions.keepConnectionAlive)
-                {
-                    await _authCache.Set(_authToken);
-                }
-            }
-            return res.SignedPayloads.Select(transaction => Transaction.Deserialize(transaction)).ToArray();
+
+            return res.SignedPayloads
+                .Select(transaction => Transaction.Deserialize(transaction)).ToArray();
         }
 
 
@@ -317,6 +382,15 @@ namespace Solana.Unity.SDK
             {
                 Debug.LogWarning($"[MWA] Auth cache clear failed during Logout: {e}");
             }
+
+            try
+            {
+                _walletSelectionCache.ClearSelectedWalletPackage().GetAwaiter().GetResult();
+            }
+            catch (Exception e)
+            {
+                Debug.LogWarning($"[MWA] Wallet selection cache clear failed during Logout: {e}");
+            }
         }
 
         public async Task DisconnectWallet()
@@ -329,8 +403,7 @@ namespace Solana.Unity.SDK
             {
                 try
                 {
-                    // TODO: change to using var after PR #260 merges (IDisposable not yet on LocalAssociationScenario)
-                    var localAssociationScenario = new LocalAssociationScenario();
+                    using var localAssociationScenario = await CreateTargetedScenario();
                     var result = await localAssociationScenario.StartAndExecute(
                         new List<Action<IAdapterOperations>>
                         {
@@ -385,7 +458,7 @@ namespace Solana.Unity.SDK
         /// </summary>
         public async Task HandleApplicationFocus(bool hasFocus)
         {
-            if (!hasFocus || !_walletOptions.keepConnectionAlive || Account != null)
+            if (!hasFocus || !_walletOptions.keepConnectionAlive || Account != null || _loginInProgress)
             {
                 return;
             }
@@ -410,8 +483,7 @@ namespace Solana.Unity.SDK
         public async Task<CapabilitiesResult> GetCapabilities()
         {
             CapabilitiesResult capabilities = null;
-            // TODO: change to using var after PR #260 merges (IDisposable not yet on LocalAssociationScenario)
-            var localAssociationScenario = new LocalAssociationScenario();
+            using var localAssociationScenario = await CreateTargetedScenario();
             var result = await localAssociationScenario.StartAndExecute(
                 new List<Action<IAdapterOperations>>
                 {
@@ -435,68 +507,23 @@ namespace Solana.Unity.SDK
 
         public override async Task<byte[]> SignMessage(byte[] message)
         {
-            if (_authToken.IsNullOrEmpty() && _walletOptions.keepConnectionAlive)
-                _authToken = await _authCache.Get();
-
             string cachedPk = Account?.PublicKey?.ToString()
                 ?? PlayerPrefs.GetString(PrefKeyPublicKey, null);
             if (string.IsNullOrEmpty(cachedPk))
                 throw new Exception("[MWA] Cannot sign message: no account available");
 
             SignedResult signedMessages = null;
-            var localAssociationScenario = new LocalAssociationScenario();
-            AuthorizationResult authorization = null;
-            var cluster = RPCNameMap[(int)RpcCluster];
-            var result = await localAssociationScenario.StartAndExecute(
-                new List<Action<IAdapterOperations>>
-                {
-                    async client =>
-                    {
-                        if (_authToken.IsNullOrEmpty())
-                        {
-                            authorization = await client.Authorize(
-                                new Uri(_walletOptions.identityUri),
-                                new Uri(_walletOptions.iconUri, UriKind.Relative),
-                                _walletOptions.name, cluster);
-                        }
-                        else
-                        {
-                            authorization = await client.Reauthorize(
-                                new Uri(_walletOptions.identityUri),
-                                new Uri(_walletOptions.iconUri, UriKind.Relative),
-                                _walletOptions.name, _authToken);   
-                        }
-                    },
-                    async client =>
-                    {
-                        signedMessages = await client.SignMessages(
-                            messages: new List<byte[]> { message },
-                            addresses: new List<byte[]> { new PublicKey(cachedPk).KeyBytes }
-                        );
-                    }
-                }
-            );
-            if (!result.WasSuccessful)
+            await RunPrivileged(async client =>
             {
-                Debug.LogError(result.Error.Message);
-                throw new Exception(result.Error.Message);
-            }
-            if (authorization == null)
-            {
-                throw new Exception("[MWA] SignMessage: authorization was not populated");
-            }
+                signedMessages = await client.SignMessages(
+                    messages: new List<byte[]> { message },
+                    addresses: new List<byte[]> { new PublicKey(cachedPk).KeyBytes }
+                );
+            }, "SignMessage");
+
             if (signedMessages == null)
-            {
                 throw new Exception("[MWA] SignMessage: signed payloads were not populated");
-            }
-            if (!string.IsNullOrEmpty(authorization.AuthToken))
-            {
-                _authToken = authorization.AuthToken;
-                if (_walletOptions.keepConnectionAlive)
-                {
-                    await _authCache.Set(_authToken);
-                }
-            }
+
             return signedMessages.SignedPayloadsBytes[0];
         }
 
@@ -504,5 +531,63 @@ namespace Solana.Unity.SDK
         {
             throw new NotImplementedException("Can't create a new account in phantom wallet");
         }
+
+    }
+}
+
+internal sealed class AuthorizeOperation
+{
+    private readonly SolanaMobileWalletAdapterOptions _opts;
+    private readonly string _cluster;
+
+    public AuthorizationResult Authorization { get; private set; }
+
+    public AuthorizeOperation(SolanaMobileWalletAdapterOptions opts, string cluster)
+    {
+        _opts = opts;
+        _cluster = cluster;
+    }
+
+    public List<Action<IAdapterOperations>> BuildActions()
+    {
+        return new List<Action<IAdapterOperations>>
+        {
+            async client =>
+            {
+                Authorization = await client.Authorize(
+                    new Uri(_opts.identityUri),
+                    new Uri(_opts.iconUri, UriKind.Relative),
+                    _opts.name,
+                    _cluster);
+            }
+        };
+    }
+}
+
+internal sealed class ReauthorizeOperation
+{
+    private readonly SolanaMobileWalletAdapterOptions _opts;
+    private readonly string _authToken;
+    
+    public AuthorizationResult Authorization { get; private set; }
+
+    public ReauthorizeOperation(SolanaMobileWalletAdapterOptions opts, string authToken)
+    {
+        _opts = opts;
+        _authToken = authToken;
+    }
+
+    public List<Action<IAdapterOperations>> BuildActions()
+    {
+        return new List<Action<IAdapterOperations>>
+        {
+            async client =>
+            {
+                Authorization = await client.Reauthorize(
+                    new Uri(_opts.identityUri),
+                    new Uri(_opts.iconUri, UriKind.Relative),
+                    _opts.name, _authToken);
+            }
+        };
     }
 }

--- a/Runtime/codebase/SolanaMobileStack/SolanaMobileWalletAdapter.cs
+++ b/Runtime/codebase/SolanaMobileStack/SolanaMobileWalletAdapter.cs
@@ -326,15 +326,17 @@ namespace Solana.Unity.SDK
             PlayerPrefs.Save();
             await _authCache.Set(_authToken);
 
-            // Try to identify and cache the wallet package from the account label so subsequent connections can target it directly.
+            // Identify and cache the wallet package so subsequent connections can
+            // target it directly: try the account label first, then fall back to
+            // the auth-token type.
             var rawLabel = authorizationOperation.Authorization.AccountLabel;
-            var resolvedFromLabel = MwaWalletDiscovery.ResolvePackageFromLabel(rawLabel);
+            var resolvedPackage = MwaWalletDiscovery.ResolvePackage(rawLabel, _authToken);
             Debug.Log($"[MWA] Login store path: AccountLabel=" +
                       (string.IsNullOrEmpty(rawLabel) ? "<empty>" : $"\"{rawLabel}\"") +
                       $" -> resolved package=" +
-                      (string.IsNullOrEmpty(resolvedFromLabel) ? "<none>" : resolvedFromLabel));
-            
-            await TryCacheWalletPackage(resolvedFromLabel);
+                      (string.IsNullOrEmpty(resolvedPackage) ? "<none>" : resolvedPackage));
+
+            await TryCacheWalletPackage(resolvedPackage);
 
             return new Account(string.Empty, publicKey);
         }

--- a/Runtime/codebase/SolanaMobileStack/SolanaMobileWalletAdapter.cs
+++ b/Runtime/codebase/SolanaMobileStack/SolanaMobileWalletAdapter.cs
@@ -25,6 +25,16 @@ namespace Solana.Unity.SDK
     [Obsolete("Use SolanaWalletAdapter class instead, which is the cross platform wrapper.")]
     public class SolanaMobileWalletAdapter : WalletBase
     {
+        private sealed class MobileWalletAdapterLifecycleHook : MonoBehaviour
+        {
+            public event Action<bool> ApplicationFocusChanged;
+
+            private void OnApplicationFocus(bool hasFocus)
+            {
+                ApplicationFocusChanged?.Invoke(hasFocus);
+            }
+        }
+
         private const string PrefKeyPublicKey = "solana_sdk.mwa.public_key";
         // Single source of truth lives in PlayerPrefsAuthCache.DefaultKey.
         // Kept here as a private alias because the legacy key migration
@@ -41,6 +51,7 @@ namespace Solana.Unity.SDK
         private readonly WalletBase _internalWallet;
         private readonly IMwaAuthCache _authCache;
         private string _authToken;
+        private static MobileWalletAdapterLifecycleHook _lifecycleHook;
 
         public event Action OnWalletDisconnected;
         public event Action OnWalletReconnected;
@@ -61,6 +72,34 @@ namespace Solana.Unity.SDK
             }
             _authCache = authCache ?? new PlayerPrefsAuthCache();
             MigrateLegacyPrefKeys();
+            EnsureLifecycleHook();
+            _lifecycleHook.ApplicationFocusChanged -= OnApplicationFocusChanged;
+            _lifecycleHook.ApplicationFocusChanged += OnApplicationFocusChanged;
+        }
+
+        private static void EnsureLifecycleHook()
+        {
+            if (_lifecycleHook != null)
+            {
+                return;
+            }
+
+            var hookObject = new GameObject("[SolanaMobileWalletAdapterLifecycle]");
+            hookObject.hideFlags = HideFlags.HideAndDontSave;
+            UnityEngine.Object.DontDestroyOnLoad(hookObject);
+            _lifecycleHook = hookObject.AddComponent<MobileWalletAdapterLifecycleHook>();
+        }
+
+        private async void OnApplicationFocusChanged(bool hasFocus)
+        {
+            try
+            {
+                await HandleApplicationFocus(hasFocus);
+            }
+            catch (Exception e)
+            {
+                Debug.LogWarning($"[MWA] OnApplicationFocus handler failed: {e.Message}");
+            }
         }
 
         private static void MigrateLegacyPrefKeys()
@@ -335,6 +374,36 @@ namespace Solana.Unity.SDK
             {
                 Debug.LogError($"[MWA] ReconnectWallet failed: {e}");
                 throw;
+            }
+        }
+
+        /// <summary>
+        /// Handles app focus resume for Android MWA flows.
+        /// Call this from a MonoBehaviour's OnApplicationFocus callback.
+        /// When focus returns and cached credentials exist, attempts a silent
+        /// reconnect only if no account is currently set.
+        /// </summary>
+        public async Task HandleApplicationFocus(bool hasFocus)
+        {
+            if (!hasFocus || !_walletOptions.keepConnectionAlive || Account != null)
+            {
+                return;
+            }
+
+            var cachedPublicKey = PlayerPrefs.GetString(PrefKeyPublicKey, null);
+            var cachedAuthToken = await _authCache.Get();
+            if (cachedPublicKey.IsNullOrEmpty() || cachedAuthToken.IsNullOrEmpty())
+            {
+                return;
+            }
+
+            try
+            {
+                await ReconnectWallet();
+            }
+            catch (Exception e)
+            {
+                Debug.LogWarning($"[MWA] HandleApplicationFocus reconnect failed: {e.Message}");
             }
         }
 

--- a/Runtime/codebase/SolanaMobileStack/SolanaMobileWalletAdapter.cs
+++ b/Runtime/codebase/SolanaMobileStack/SolanaMobileWalletAdapter.cs
@@ -326,26 +326,18 @@ namespace Solana.Unity.SDK
             PlayerPrefs.Save();
             await _authCache.Set(_authToken);
 
-            //Cache wallet package = chooser pick first, else label/token fallback
-            var rawLabel = authorizationOperation.Authorization.AccountLabel;
             var chosenPackage = MwaNativeChooser.ConsumeChosenPackage();
-            string resolvedPackage;
             if (!string.IsNullOrEmpty(chosenPackage))
             {
-                resolvedPackage = chosenPackage;
+                var rawLabel = authorizationOperation.Authorization.AccountLabel;
                 Debug.Log($"[MWA] Login store path: chooser-selected package={chosenPackage}" +
                           (string.IsNullOrEmpty(rawLabel) ? "" : $" (label=\"{rawLabel}\")"));
+                await TryCacheWalletPackage(chosenPackage);
             }
             else
             {
-                resolvedPackage = MwaWalletDiscovery.ResolvePackage(rawLabel, _authToken);
-                Debug.Log($"[MWA] Login store path: AccountLabel=" +
-                          (string.IsNullOrEmpty(rawLabel) ? "<empty>" : $"\"{rawLabel}\"") +
-                          $" -> resolved package=" +
-                          (string.IsNullOrEmpty(resolvedPackage) ? "<none>" : resolvedPackage));
+                Debug.Log("[MWA] Login store path: no chooser package captured; wallet not cached.");
             }
-
-            await TryCacheWalletPackage(resolvedPackage);
 
             return new Account(string.Empty, publicKey);
         }

--- a/Runtime/codebase/SolanaWalletAdapter.cs
+++ b/Runtime/codebase/SolanaWalletAdapter.cs
@@ -23,11 +23,24 @@ namespace Solana.Unity.SDK
         public event Action OnWalletDisconnected;
         public event Action OnWalletReconnected;
 
-        public SolanaWalletAdapter(SolanaWalletAdapterOptions options, RpcCluster rpcCluster = RpcCluster.DevNet, string customRpcUri = null, string customStreamingRpcUri = null, bool autoConnectOnStartup = false) : base(rpcCluster, customRpcUri, customStreamingRpcUri, autoConnectOnStartup)
+        /// <summary>
+        /// Creates a cross-platform wallet adapter.
+        /// </summary>
+        /// <param name="authCache">
+        /// Optional Mobile Wallet Adapter auth-token cache. Forwarded to the
+        /// Android <see cref="SolanaMobileWalletAdapter"/>. Ignored on WebGL
+        /// and iOS since those platforms do not use MWA bearer tokens. When
+        /// left <c>null</c> the SDK falls back to
+        /// <see cref="PlayerPrefsAuthCache"/>. Pass a custom
+        /// <see cref="IMwaAuthCache"/> (e.g. Android Keystore /
+        /// EncryptedSharedPreferences) for production builds that need
+        /// encryption at rest.
+        /// </param>
+        public SolanaWalletAdapter(SolanaWalletAdapterOptions options, RpcCluster rpcCluster = RpcCluster.DevNet, string customRpcUri = null, string customStreamingRpcUri = null, bool autoConnectOnStartup = false, IMwaAuthCache authCache = null) : base(rpcCluster, customRpcUri, customStreamingRpcUri, autoConnectOnStartup)
         {
             #if UNITY_ANDROID
             #pragma warning disable CS0618
-            _internalWallet = new SolanaMobileWalletAdapter(options.solanaMobileWalletAdapterOptions, rpcCluster, customRpcUri, customStreamingRpcUri, autoConnectOnStartup);
+            _internalWallet = new SolanaMobileWalletAdapter(options.solanaMobileWalletAdapterOptions, rpcCluster, customRpcUri, customStreamingRpcUri, autoConnectOnStartup, authCache);
             #elif UNITY_WEBGL
             #pragma warning disable CS0618
             _internalWallet = new SolanaWalletAdapterWebGL(options.solanaWalletAdapterWebGLOptions, rpcCluster, customRpcUri, customStreamingRpcUri, autoConnectOnStartup);

--- a/Runtime/codebase/SolanaWalletAdapter.cs
+++ b/Runtime/codebase/SolanaWalletAdapter.cs
@@ -36,11 +36,17 @@ namespace Solana.Unity.SDK
         /// EncryptedSharedPreferences) for production builds that need
         /// encryption at rest.
         /// </param>
-        public SolanaWalletAdapter(SolanaWalletAdapterOptions options, RpcCluster rpcCluster = RpcCluster.DevNet, string customRpcUri = null, string customStreamingRpcUri = null, bool autoConnectOnStartup = false, IMwaAuthCache authCache = null) : base(rpcCluster, customRpcUri, customStreamingRpcUri, autoConnectOnStartup)
+        /// <param name="walletSelectionCache">
+        /// Optional cache for the user's wallet package selection. Forwarded to
+        /// the Android <see cref="SolanaMobileWalletAdapter"/>. Ignored on
+        /// other platforms. When left <c>null</c> the SDK falls back to
+        /// <see cref="PlayerPrefsMwaWalletSelectionCache"/>.
+        /// </param>
+        public SolanaWalletAdapter(SolanaWalletAdapterOptions options, RpcCluster rpcCluster = RpcCluster.DevNet, string customRpcUri = null, string customStreamingRpcUri = null, bool autoConnectOnStartup = false, IMwaAuthCache authCache = null, IMwaWalletSelectionCache walletSelectionCache = null) : base(rpcCluster, customRpcUri, customStreamingRpcUri, autoConnectOnStartup)
         {
             #if UNITY_ANDROID
             #pragma warning disable CS0618
-            _internalWallet = new SolanaMobileWalletAdapter(options.solanaMobileWalletAdapterOptions, rpcCluster, customRpcUri, customStreamingRpcUri, autoConnectOnStartup, authCache);
+            _internalWallet = new SolanaMobileWalletAdapter(options.solanaMobileWalletAdapterOptions, rpcCluster, customRpcUri, customStreamingRpcUri, autoConnectOnStartup, authCache, walletSelectionCache);
             #elif UNITY_WEBGL
             #pragma warning disable CS0618
             _internalWallet = new SolanaWalletAdapterWebGL(options.solanaWalletAdapterWebGLOptions, rpcCluster, customRpcUri, customStreamingRpcUri, autoConnectOnStartup);

--- a/Runtime/codebase/SolanaWalletAdapter.cs
+++ b/Runtime/codebase/SolanaWalletAdapter.cs
@@ -125,6 +125,19 @@ namespace Solana.Unity.SDK
         }
 
         /// <summary>
+        /// Forwards app-focus lifecycle to platform adapters that need it.
+        /// Currently used by Android MWA for silent resume checks.
+        /// </summary>
+        public async Task HandleApplicationFocus(bool hasFocus)
+        {
+            var mobileAdapter = _internalWallet as SolanaMobileWalletAdapter;
+            if (mobileAdapter != null)
+            {
+                await mobileAdapter.HandleApplicationFocus(hasFocus);
+            }
+        }
+
+        /// <summary>
         /// Queries the connected wallet's supported features and limits.
         /// </summary>
         /// <returns>

--- a/Runtime/codebase/SolanaWalletAdapterWebGL/SolanaWalletAdapterWebGL.cs
+++ b/Runtime/codebase/SolanaWalletAdapterWebGL/SolanaWalletAdapterWebGL.cs
@@ -1,7 +1,8 @@
-﻿using System;
+using System;
 using System.Runtime.InteropServices;
 using System.Threading.Tasks;
 using AOT;
+using Newtonsoft.Json;
 using Solana.Unity.Rpc.Models;
 using Solana.Unity.Wallet;
 using UnityEngine;
@@ -53,6 +54,26 @@ namespace Solana.Unity.SDK
         private static WalletSpecs _currentWallet;
 
         private static string _clusterName;
+        private static string _subscribedWalletName;
+        private static bool _walletEventsSubscribed;
+
+        [Serializable]
+        private class WalletAdapterEventPayload
+        {
+            public string @event;
+            public string publicKey;
+            public string account;
+            public string[] accounts;
+            public string walletName;
+            public string error;
+        }
+
+        /// <summary>
+        /// Fired when the WebGL wallet provider emits lifecycle/account events.
+        /// Payload comes from the JS bridge and can include:
+        /// event, walletName, publicKey/account/accounts, error.
+        /// </summary>
+        public static event Action<string> OnWalletAdapterEvent;
             
 
         [Obsolete("Use SolanaWalletAdapter class instead, which is the cross platform wrapper.")]
@@ -173,6 +194,12 @@ namespace Solana.Unity.SDK
             ExternSignMessageWallet(_currentWallet.name, base64MessageStr, OnMessageSigned);
             return _signedMessageTaskCompletionSource.Task;
         }
+        public override void Logout()
+        {
+            base.Logout();
+            _account = null;
+            TryUnsubscribeWalletEvents();
+        }
 
         protected override Task<Account> _CreateAccount(string mnemonic = null, string password = null)
         {
@@ -208,6 +235,7 @@ namespace Solana.Unity.SDK
             }
             Debug.Log($"Wallet {walletPubKey} connected!");
             _account = new Account("", walletPubKey);
+            TrySubscribeWalletEvents();
             _loginTaskCompletionSource.TrySetResult(_account);
         }
 
@@ -286,6 +314,77 @@ namespace Solana.Unity.SDK
             _getWalletsTaskCompletionSource.SetResult(walletsData);
         }
 
+        [MonoPInvokeCallback(typeof(Action<string>))]
+        private static void OnWalletEvent(string payload)
+        {
+            if (string.IsNullOrEmpty(payload))
+            {
+                return;
+            }
+
+            OnWalletAdapterEvent?.Invoke(payload);
+
+            try
+            {
+                var evt = JsonConvert.DeserializeObject<WalletAdapterEventPayload>(payload);
+                if (evt == null)
+                {
+                    return;
+                }
+
+                string eventName = evt.@event ?? string.Empty;
+                if (eventName.Equals("disconnect", StringComparison.OrdinalIgnoreCase))
+                {
+                    _account = null;
+                    return;
+                }
+
+                if (eventName.Equals("accountsChanged", StringComparison.OrdinalIgnoreCase) ||
+                    eventName.Equals("accountChanged", StringComparison.OrdinalIgnoreCase) ||
+                    eventName.Equals("change", StringComparison.OrdinalIgnoreCase))
+                {
+                    var nextPk = evt.publicKey ?? evt.account;
+                    if (!string.IsNullOrEmpty(nextPk))
+                    {
+                        _account = new Account("", nextPk);
+                    }
+                }
+            }
+            catch (Exception e)
+            {
+                Debug.LogWarning($"[WebGL] Failed to parse wallet event payload: {e.Message}");
+            }
+        }
+
+        private static void TrySubscribeWalletEvents()
+        {
+            if (_currentWallet == null || string.IsNullOrEmpty(_currentWallet.name))
+            {
+                return;
+            }
+
+            if (_walletEventsSubscribed && string.Equals(_subscribedWalletName, _currentWallet.name, StringComparison.Ordinal))
+            {
+                return;
+            }
+
+            TryUnsubscribeWalletEvents();
+            ExternSubscribeWalletEvents(_currentWallet.name, OnWalletEvent);
+            _subscribedWalletName = _currentWallet.name;
+            _walletEventsSubscribed = true;
+        }
+
+        private static void TryUnsubscribeWalletEvents()
+        {
+            if (!_walletEventsSubscribed || string.IsNullOrEmpty(_subscribedWalletName))
+            {
+                return;
+            }
+
+            ExternUnsubscribeWalletEvents(_subscribedWalletName);
+            _subscribedWalletName = null;
+            _walletEventsSubscribed = false;
+        }
         #endregion
 
         #if UNITY_WEBGL
@@ -308,6 +407,12 @@ namespace Solana.Unity.SDK
 
                 [DllImport("__Internal")]
                 private static extern void InitWalletAdapter(Action<bool> callback, string clusterName);
+
+                [DllImport("__Internal")]
+                private static extern void ExternSubscribeWalletEvents(string walletName, Action<string> callback);
+
+                [DllImport("__Internal")]
+                private static extern void ExternUnsubscribeWalletEvents(string walletName);
                 
                 
         #else
@@ -317,7 +422,19 @@ namespace Solana.Unity.SDK
                 private static void ExternSignMessageWallet(string walletName, string messageBase64, Action<string> callback){}
                 private static string ExternGetWallets(Action<string> callback){return null;}
                 private static void InitWalletAdapter(Action<bool> callback, string clusterName){}
+                private static void ExternSubscribeWalletEvents(string walletName, Action<string> callback){}
+                private static void ExternUnsubscribeWalletEvents(string walletName){}
                 
         #endif
     }
 }
+
+
+
+
+
+
+
+
+
+

--- a/Runtime/codebase/Web3.cs
+++ b/Runtime/codebase/Web3.cs
@@ -304,7 +304,7 @@ namespace Solana.Unity.SDK
             _solAmount = 0;
             if(_nfts != null) _nfts.Clear();
         }
-        
+
         #region Helpers
 
         /// <summary>

--- a/Tests/EditMode/MwaAuthCache.meta
+++ b/Tests/EditMode/MwaAuthCache.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: c0f754e266c440818475f0ff0725124c
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Tests/EditMode/MwaAuthCache/PlayerPrefsAuthCacheTests.cs
+++ b/Tests/EditMode/MwaAuthCache/PlayerPrefsAuthCacheTests.cs
@@ -1,0 +1,291 @@
+using NUnit.Framework;
+using System.Linq;
+using System.Reflection;
+using System.Threading.Tasks;
+using UnityEngine;
+
+// ReSharper disable once CheckNamespace
+namespace Solana.Unity.SDK.Tests.EditMode.MwaAuthCache
+{
+    /// <summary>
+    /// EditMode tests for <see cref="PlayerPrefsAuthCache"/> and the
+    /// <see cref="IMwaAuthCache"/> wiring on both adapters.
+    ///
+    /// Tests must not stomp on a developer's real PlayerPrefs values, so
+    /// any key we touch gets snapshotted in <see cref="SetUp"/> and restored
+    /// in <see cref="TearDown"/>. Same convention as
+    /// SolanaMobileWalletAdapterPrefsTests in PR #283.
+    /// </summary>
+    [TestFixture]
+    [Category("MwaAuthCache")]
+    public class PlayerPrefsAuthCacheTests
+    {
+        // Duplicated here on purpose. If someone renames
+        // PlayerPrefsAuthCache.DefaultKey, the BC test below should fail and
+        // force a deliberate review.
+        private const string DefaultKey = "solana_sdk.mwa.auth_token";
+        private const string ScopedSuffix = "phantom";
+        private const string ScopedKey = DefaultKey + "." + ScopedSuffix;
+
+        private bool _hadDefault;
+        private string _savedDefault;
+        private bool _hadScoped;
+        private string _savedScoped;
+
+        [SetUp]
+        public void SetUp()
+        {
+            _hadDefault = PlayerPrefs.HasKey(DefaultKey);
+            _savedDefault = _hadDefault ? PlayerPrefs.GetString(DefaultKey) : null;
+            _hadScoped = PlayerPrefs.HasKey(ScopedKey);
+            _savedScoped = _hadScoped ? PlayerPrefs.GetString(ScopedKey) : null;
+
+            PlayerPrefs.DeleteKey(DefaultKey);
+            PlayerPrefs.DeleteKey(ScopedKey);
+            PlayerPrefs.Save();
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            PlayerPrefs.DeleteKey(DefaultKey);
+            PlayerPrefs.DeleteKey(ScopedKey);
+
+            if (_hadDefault) PlayerPrefs.SetString(DefaultKey, _savedDefault);
+            if (_hadScoped) PlayerPrefs.SetString(ScopedKey, _savedScoped);
+
+            PlayerPrefs.Save();
+        }
+
+        // ---------- Get / Set / Clear semantics ----------
+
+        [Test]
+        public async Task Get_ReturnsNull_WhenKeyMissing()
+        {
+            var cache = new PlayerPrefsAuthCache();
+
+            string token = await cache.Get();
+
+            // Empty string would be indistinguishable from "fresh install"
+            // for the SDK's _authToken.IsNullOrEmpty() checks, so the cache
+            // contract requires null on miss.
+            Assert.IsNull(token);
+        }
+
+        [Test]
+        public async Task SetThenGet_RoundTripsToken()
+        {
+            var cache = new PlayerPrefsAuthCache();
+
+            await cache.Set("token-abc-123");
+            string read = await cache.Get();
+
+            Assert.AreEqual("token-abc-123", read);
+        }
+
+        [Test]
+        public async Task Set_PersistsToken_VisibleViaPlayerPrefs()
+        {
+            var cache = new PlayerPrefsAuthCache();
+
+            await cache.Set("token-via-cache");
+
+            // Direct PlayerPrefs read must see the same value. This is the
+            // contract that lets PR #269 sessions survive the upgrade with
+            // no migration step.
+            Assert.AreEqual("token-via-cache",
+                PlayerPrefs.GetString(DefaultKey, null));
+        }
+
+        [Test]
+        public async Task Set_WithEmptyToken_IsNoOp()
+        {
+            var cache = new PlayerPrefsAuthCache();
+            PlayerPrefs.SetString(DefaultKey, "preexisting");
+            PlayerPrefs.Save();
+
+            await cache.Set(string.Empty);
+
+            // A stale callsite passing "" must not wipe a valid session.
+            Assert.AreEqual("preexisting", PlayerPrefs.GetString(DefaultKey, null));
+        }
+
+        [Test]
+        public async Task Set_WithNullToken_IsNoOp()
+        {
+            var cache = new PlayerPrefsAuthCache();
+            PlayerPrefs.SetString(DefaultKey, "preexisting");
+            PlayerPrefs.Save();
+
+            await cache.Set(null);
+
+            // Same reasoning as the empty-string case.
+            Assert.AreEqual("preexisting", PlayerPrefs.GetString(DefaultKey, null));
+        }
+
+        [Test]
+        public async Task Clear_RemovesPersistedToken()
+        {
+            var cache = new PlayerPrefsAuthCache();
+            await cache.Set("to-be-cleared");
+
+            await cache.Clear();
+
+            Assert.IsFalse(PlayerPrefs.HasKey(DefaultKey));
+            Assert.IsNull(await cache.Get());
+        }
+
+        [Test]
+        public async Task Clear_OnEmptyCache_IsIdempotent()
+        {
+            var cache = new PlayerPrefsAuthCache();
+
+            // Logout() and DisconnectWallet() can both call Clear in a row,
+            // so back-to-back invocations on an empty cache must be safe.
+            await cache.Clear();
+            await cache.Clear();
+
+            Assert.IsNull(await cache.Get());
+        }
+
+        // ---------- Scoping ----------
+
+        [Test]
+        public async Task ScopedCache_WritesToScopedKey()
+        {
+            var scoped = new PlayerPrefsAuthCache(ScopedSuffix);
+
+            await scoped.Set("scoped-token");
+
+            Assert.AreEqual("scoped-token", PlayerPrefs.GetString(ScopedKey, null));
+            // Scoped writes must not leak into the unscoped default bucket.
+            Assert.IsFalse(PlayerPrefs.HasKey(DefaultKey));
+        }
+
+        [Test]
+        public async Task ScopedCache_DoesNotSeeUnscopedToken()
+        {
+            // Apps that connect to multiple wallets (e.g. Phantom + Solflare)
+            // need each scope to be a separate bucket.
+            var unscoped = new PlayerPrefsAuthCache();
+            var scoped = new PlayerPrefsAuthCache(ScopedSuffix);
+            await unscoped.Set("only-in-default");
+
+            Assert.IsNull(await scoped.Get());
+        }
+
+        [Test]
+        public async Task UnscopedCache_DoesNotSeeScopedToken()
+        {
+            var unscoped = new PlayerPrefsAuthCache();
+            var scoped = new PlayerPrefsAuthCache(ScopedSuffix);
+            await scoped.Set("only-in-scoped");
+
+            Assert.IsNull(await unscoped.Get());
+        }
+
+        [Test]
+        public void Constructor_WithEmptyScope_FallsBackToDefaultKey()
+        {
+            var emptyScope = new PlayerPrefsAuthCache(string.Empty);
+            var nullScope = new PlayerPrefsAuthCache(null);
+            var noArg = new PlayerPrefsAuthCache();
+
+            string keyEmpty = GetPrivateKey(emptyScope);
+            string keyNull = GetPrivateKey(nullScope);
+            string keyNoArg = GetPrivateKey(noArg);
+
+            Assert.AreEqual(DefaultKey, keyEmpty);
+            Assert.AreEqual(DefaultKey, keyNull);
+            Assert.AreEqual(DefaultKey, keyNoArg);
+        }
+
+        // ---------- Backward compatibility with PR #269 ----------
+
+        [Test]
+        public void DefaultKey_StaysOnPR269Constant()
+        {
+            // DefaultKey is the anchor for backward compatibility. If
+            // someone changes its value, every existing install loses its
+            // cached session on upgrade. That should never be a quiet
+            // change, so we pin it here.
+            FieldInfo field = typeof(PlayerPrefsAuthCache).GetField(
+                "DefaultKey",
+                BindingFlags.Public | BindingFlags.Static);
+
+            Assert.IsNotNull(field);
+            Assert.AreEqual(DefaultKey, field.GetRawConstantValue() as string);
+        }
+
+        [Test]
+        public async Task PreExisting_PR269_TokenIsReadableByDefaultCache()
+        {
+            // Simulate an install that connected on main after PR #269
+            // shipped, before this abstraction existed. Their token is
+            // sitting at solana_sdk.mwa.auth_token. After upgrade, the
+            // default cache must still find it - no migration ever runs.
+            PlayerPrefs.SetString(DefaultKey, "session-from-pr269");
+            PlayerPrefs.Save();
+
+            var cache = new PlayerPrefsAuthCache();
+
+            Assert.AreEqual("session-from-pr269", await cache.Get());
+        }
+
+        // ---------- Adapter wiring contract ----------
+        //
+        // These tests catch the case where a future refactor accidentally
+        // drops the optional IMwaAuthCache parameter from either adapter
+        // constructor. Without it, custom cache injection silently breaks
+        // and there's no compile error to flag the regression.
+
+        [Test]
+        public void SolanaMobileWalletAdapter_AcceptsOptionalIMwaAuthCache()
+        {
+            var ctor = FindCtorWithAuthCacheParam(
+                typeof(SolanaMobileWalletAdapter));
+
+            Assert.IsNotNull(ctor);
+
+            ParameterInfo authCacheParam = ctor.GetParameters()
+                .First(p => p.ParameterType == typeof(IMwaAuthCache));
+            // Optional + default null = backward compatible. Existing
+            // call sites that don't pass authCache must still compile.
+            Assert.IsTrue(authCacheParam.IsOptional);
+            Assert.IsNull(authCacheParam.DefaultValue);
+        }
+
+        [Test]
+        public void SolanaWalletAdapter_AcceptsOptionalIMwaAuthCache()
+        {
+            var ctor = FindCtorWithAuthCacheParam(typeof(SolanaWalletAdapter));
+
+            Assert.IsNotNull(ctor);
+
+            ParameterInfo authCacheParam = ctor.GetParameters()
+                .First(p => p.ParameterType == typeof(IMwaAuthCache));
+            Assert.IsTrue(authCacheParam.IsOptional);
+            Assert.IsNull(authCacheParam.DefaultValue);
+        }
+
+        // ---------- Helpers ----------
+
+        private static string GetPrivateKey(PlayerPrefsAuthCache cache)
+        {
+            // _key is the live storage contract for an instance. Renaming
+            // it requires updating these tests.
+            FieldInfo field = typeof(PlayerPrefsAuthCache).GetField(
+                "_key",
+                BindingFlags.NonPublic | BindingFlags.Instance);
+            Assert.IsNotNull(field);
+            return (string)field.GetValue(cache);
+        }
+
+        private static ConstructorInfo FindCtorWithAuthCacheParam(System.Type t)
+        {
+            return t.GetConstructors()
+                .FirstOrDefault(c => c.GetParameters()
+                    .Any(p => p.ParameterType == typeof(IMwaAuthCache)));
+        }
+    }
+}

--- a/Tests/EditMode/MwaAuthCache/PlayerPrefsAuthCacheTests.cs.meta
+++ b/Tests/EditMode/MwaAuthCache/PlayerPrefsAuthCacheTests.cs.meta
@@ -1,11 +1,2 @@
 fileFormatVersion: 2
 guid: f80b6d064e214da7ba83e16e03f89c08
-MonoImporter:
-  externalObjects: {}
-  serializedVersion: 2
-  defaultReferences: []
-  executionOrder: 0
-  icon: {instanceID: 0}
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 

--- a/Tests/EditMode/MwaAuthCache/PlayerPrefsAuthCacheTests.cs.meta
+++ b/Tests/EditMode/MwaAuthCache/PlayerPrefsAuthCacheTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: f80b6d064e214da7ba83e16e03f89c08
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
> ⚠️ NOTE: Foundation PR for Issues #271 and #272 (duplicate trackers for the
> same `IMwaAuthCache` ask). Default behavior is unchanged from PR #269:
> existing cached sessions continue to work with zero migration. The new
> value is the seam: developers can now plug in Android Keystore /
> EncryptedSharedPreferences for at-rest encryption without forking the SDK.
> No public method signatures change. Adds optional ctor parameter only.

| Status | Type    | ⚠️ Core Change | Issues                                                                                                                                                       |
| :----: | :-----: | :------------: | :----------------------------------------------------------------------------------------------------------------------------------------------------------: |
| Ready  | Feature | No             | [#271](https://github.com/magicblock-labs/Solana.Unity-SDK/issues/271), [#272](https://github.com/magicblock-labs/Solana.Unity-SDK/issues/272) |

## Problem

PR #269 fixed the auth-token lifecycle but left token persistence hardcoded
to `PlayerPrefs`. PlayerPrefs is plaintext app storage on Android: a local
device compromise, an `adb backup`, or a rooted-device dump can extract the
bearer token and replay the session against the wallet.

Issues #271 and #272 (duplicate trackers, same ask) request the SDK make
this layer pluggable so developers shipping production games can inject
platform-secure storage (Android Keystore, EncryptedSharedPreferences, iOS
Keychain) without touching SDK internals.

There is no abstraction today. `SolanaMobileWalletAdapter` writes the token
directly to a hardcoded `PlayerPrefs` key, and every read/write/delete site
in `_Login`, `_SignAllTransactions`, `SignMessage`, `Logout`, and
`DisconnectWallet` does the same thing inline.

## Solution

Introduce a narrow `IMwaAuthCache` interface (`Get` / `Set` / `Clear`,
auth-token only) plus a default `PlayerPrefsAuthCache` implementation that
preserves the existing storage key `solana_sdk.mwa.auth_token`. Both
adapters accept the cache as an optional constructor argument that defaults
to the PlayerPrefs implementation.

**Why a 3-method interface, token only:**
- Public keys are non-sensitive on-chain identifiers; forcing every secure
  backend to encrypt them adds work for no security benefit.
- Smaller surface = easier for developers to write a Keystore-backed impl
  and harder to ship a buggy one.
- Matches the contract worded in Issues #271 and #272 verbatim.

**Why keep `solana_sdk.mwa.auth_token` as the default key:**
- Users who connected on `main` after PR #269 keep their session on
  upgrade; no migration code, no silent logout.
- The key literal exists in exactly one production location now
  (`PlayerPrefsAuthCache.DefaultKey`); `SolanaMobileWalletAdapter.PrefKeyAuthToken`
  aliases it as a compile-time constant chain.

**Backward compatibility:**
- `Logout()` stays `override void`, the `WalletBase` override contract is
  unchanged. The cache `Clear()` call is awaited synchronously inside it.
- Both adapter constructors append the new `IMwaAuthCache authCache = null`
  parameter at the end with default `null`. Every existing call site
  (including `Web3.LoginWalletAdapter()`) compiles unchanged.
- `MigrateLegacyPrefKeys()` from PR #269 is left untouched: pre-#269 installs
  upgrading directly to this PR still get migrated from the legacy `pk` /
  `authToken` keys.

**Optional per-identity scoping:**
`new PlayerPrefsAuthCache("phantom")` writes to
`solana_sdk.mwa.auth_token.phantom`. Useful for apps that connect to
multiple wallet identities. Default (no scope) is backward compatible.

## Before & After Screenshots

**BEFORE**: Token persistence hardcoded to `PlayerPrefs`

**AFTER**: Adapter routes through `IMwaAuthCache`, default impl preserves PR #269 behavior, custom impls plug in via constructor:

<img width="705" height="719" alt="image" src="https://github.com/user-attachments/assets/f66e4958-9a64-45ff-a44a-9a3e64f14496" />



https://github.com/user-attachments/assets/0bd74e6f-4dae-4abc-b2aa-0387c8e3045d




- cold launch -> MWA prompt -> approve -> play -> close
- reopen -> silent reconnect, no prompt
- in-game Logout -> close -> reopen -> fresh prompt (cache cleared)]

**Custom cache injection example** (lives in PR body, not in SDK):

```csharp
public class FileAuthCache : IMwaAuthCache
{
    private readonly string _path =
        Path.Combine(Application.persistentDataPath, "mwa_auth.bin");

    public Task<string> Get()
    {
        if (!File.Exists(_path)) return Task.FromResult<string>(null);
        var v = File.ReadAllText(_path);
        return Task.FromResult(string.IsNullOrEmpty(v) ? null : v);
    }

    public Task Set(string authToken)
    {
        if (string.IsNullOrEmpty(authToken)) return Task.CompletedTask;
        File.WriteAllText(_path, authToken);
        return Task.CompletedTask;
    }

    public Task Clear()
    {
        if (File.Exists(_path)) File.Delete(_path);
        return Task.CompletedTask;
    }
}

// Inject:
var adapter = new SolanaWalletAdapter(
    options, rpcCluster, customRpc, webSocketsRpc,
    autoConnectOnStartup: false,
    authCache: new FileAuthCache());
```

## Other changes (e.g. bug fixes, small refactors)

- Single source of truth for the auth-token key. The literal
  `"solana_sdk.mwa.auth_token"` now lives only in
  `PlayerPrefsAuthCache.DefaultKey`. `SolanaMobileWalletAdapter.PrefKeyAuthToken`
  is now `private const string PrefKeyAuthToken = PlayerPrefsAuthCache.DefaultKey;`,
  preserving the named constant pattern requested on PR #269 while removing
  the duplicated literal.
- Auth-token reads/writes in the adapter are now async-aware (`await
  _authCache.Get()` / `await _authCache.Set(...)` / `await _authCache.Clear()`)
  inside the existing `async` methods. `Logout()` is the only sync entry
  point; it uses `.GetAwaiter().GetResult()` on `Clear()` to keep the
  `WalletBase` override contract.
- `[Preserve]` attribute on `PlayerPrefsAuthCache` so IL2CPP code stripping
  does not remove it in AOT builds.
- Coexists cleanly with open PR #283 (test coverage): no changes to
  `IAdapterOperations` (still 6 methods), `MigrateLegacyPrefKeys` body /
  signature / access untouched, `PrefKeyPublicKey` and `PrefKeyAuthToken`
  constants still declared. All four #283 reflection tests stay green.

## Deploy Notes

Runtime change. No new external dependencies. No Unity Editor / build
pipeline changes. No new package references in `EditMode.asmdef`.

**New scripts**:

- `Runtime/codebase/SolanaMobileStack/MwaAuthCache/IMwaAuthCache.cs` : 3-method interface (`Get` / `Set` / `Clear`) for auth-token persistence.
- `Runtime/codebase/SolanaMobileStack/MwaAuthCache/PlayerPrefsAuthCache.cs` : default `IMwaAuthCache` implementation backed by `PlayerPrefs`. Optional scope arg on the second constructor for per-identity bucketing.
- `Tests/EditMode/MwaAuthCache/PlayerPrefsAuthCacheTests.cs` : ~14 EditMode tests covering round-trip, no-op on empty/null input, idempotent clear, scope isolation, backward-compat with the PR #269 key, and reflection guards on both adapter constructors.

**Modified scripts**:

- `Runtime/codebase/SolanaMobileStack/SolanaMobileWalletAdapter.cs` : routes every auth-token read/write through `_authCache`, accepts optional `IMwaAuthCache` ctor argument, retains `MigrateLegacyPrefKeys` and both `PrefKey*` constants for PR #283 compatibility.
- `Runtime/codebase/SolanaWalletAdapter.cs` : forwards the optional cache to the Android `SolanaMobileWalletAdapter`. WebGL and iOS branches ignore the parameter (those platforms do not use MWA bearer tokens).

**New dependencies**:

- None.

Tested on Android (Solana Seeker via Mobile Wallet Adapter) in CrossyRoad: https://github.com/JoshhSandhu/CrossyRoad

Closes #271
Closes #272

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Configurable auth-token persistence with a default local-storage implementation and optional scoped token buckets; adapters accept injectable auth-cache and wallet-selection cache.
  * Android: native chooser integration, targeted association intents, selection caching, and silent reconnect on app focus.
  * WebGL: subscribe/unsubscribe support for wallet lifecycle/account events.
  * SessionWallet: new factory overload to create a session from provided keys.

* **Refactor**
  * Association flow rewritten for timeouts, cancellation, and robust websocket/key-exchange handling.

* **Tests**
  * Added tests for storage behavior, scoped/backward-compatible keys, cache-injection wiring, and clear/round-trip scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->