### PR TITLE
fix(mwa): send CAIP-2 chain so MWA 2.0 wallets (Seeker Seed Vault) use the correct network

### DIFF
--- a/Runtime/codebase/SolanaMobileStack/Interfaces/IAdapterOperations.cs
+++ b/Runtime/codebase/SolanaMobileStack/Interfaces/IAdapterOperations.cs
@@ -12,7 +12,11 @@ public interface IAdapterOperations
     // chain: optional CAIP-2 identifier (e.g. "solana:devnet") for MWA 2.0 wallets.
     public Task<AuthorizationResult> Authorize(Uri identityUri, Uri iconUri, string identityName, string rpcCluster, string chain = null);
     [Preserve]
-    public Task<AuthorizationResult> Reauthorize(Uri identityUri, Uri iconUri, string identityName, string authToken);
+    // rpcCluster/chain: MWA 2.0 requires the network identifier on reauthorize too.
+    // The spec deprecates the standalone reauthorize in favour of authorize carrying an
+    // auth_token; when chain is absent the wallet (e.g. Seeker Seed Vault) defaults the
+    // re-established session to solana:mainnet, causing a "Network mismatch" at sign time.
+    public Task<AuthorizationResult> Reauthorize(Uri identityUri, Uri iconUri, string identityName, string authToken, string rpcCluster = null, string chain = null);
     [Preserve]
     public Task Deauthorize(string authToken);
     [Preserve]

--- a/Runtime/codebase/SolanaMobileStack/Interfaces/IAdapterOperations.cs
+++ b/Runtime/codebase/SolanaMobileStack/Interfaces/IAdapterOperations.cs
@@ -9,7 +9,8 @@ using UnityEngine.Scripting;
 public interface IAdapterOperations
 {
     [Preserve]
-    public Task<AuthorizationResult> Authorize(Uri identityUri, Uri iconUri, string identityName, string rpcCluster);
+    // chain: optional CAIP-2 identifier (e.g. "solana:devnet") for MWA 2.0 wallets.
+    public Task<AuthorizationResult> Authorize(Uri identityUri, Uri iconUri, string identityName, string rpcCluster, string chain = null);
     [Preserve]
     public Task<AuthorizationResult> Reauthorize(Uri identityUri, Uri iconUri, string identityName, string authToken);
     [Preserve]

--- a/Runtime/codebase/SolanaMobileStack/JsonRpcClient/JsonRequest.cs
+++ b/Runtime/codebase/SolanaMobileStack/JsonRpcClient/JsonRequest.cs
@@ -48,6 +48,15 @@ namespace Solana.Unity.SDK
             [RequiredMember]
             public string Cluster { get; set; }
 
+            // MWA 2.0 renamed the network identifier from "cluster" to "chain" using
+            // CAIP-2 values (e.g. "solana:devnet"). Wallets implementing the 2.0 spec
+            // (e.g. Seeker Seed Vault) ignore the legacy "cluster" field and default to
+            // "solana:mainnet" when "chain" is absent. Both are serialized for
+            // backward/forward compatibility across MWA 1.x and 2.0 wallets.
+            [JsonProperty("chain", NullValueHandling = NullValueHandling.Ignore)]
+            [RequiredMember]
+            public string Chain { get; set; }
+
             [JsonProperty("auth_token", NullValueHandling = NullValueHandling.Ignore)]
             [RequiredMember]
             

--- a/Runtime/codebase/SolanaMobileStack/MobileWalletAdapterClient.cs
+++ b/Runtime/codebase/SolanaMobileStack/MobileWalletAdapterClient.cs
@@ -21,15 +21,16 @@ public class MobileWalletAdapterClient: JsonRpc20Client, IAdapterOperations, IMe
     }
     
     [Preserve]
-    public Task<AuthorizationResult> Authorize(Uri identityUri, Uri iconUri, string identityName, string cluster)
+    public Task<AuthorizationResult> Authorize(Uri identityUri, Uri iconUri, string identityName, string cluster, string chain = null)
     {
         var request = PrepareAuthRequest(
             identityUri,
-            iconUri, 
-            identityName, 
+            iconUri,
+            identityName,
             cluster,
-            "authorize");
-        
+            "authorize",
+            chain);
+
         return SendRequest<AuthorizationResult>(request);
     }
 
@@ -71,7 +72,7 @@ public class MobileWalletAdapterClient: JsonRpc20Client, IAdapterOperations, IMe
         return SendRequest<SignedResult>(request);
     }
 
-    private JsonRequest PrepareAuthRequest(Uri uriIdentity, Uri icon, string name, string cluster, string method)
+    private JsonRequest PrepareAuthRequest(Uri uriIdentity, Uri icon, string name, string cluster, string method, string chain = null)
     {
         if (uriIdentity != null && !uriIdentity.IsAbsoluteUri)
         {
@@ -93,7 +94,8 @@ public class MobileWalletAdapterClient: JsonRpc20Client, IAdapterOperations, IMe
                     Icon = icon,
                     Name = name
                 },
-                Cluster = cluster
+                Cluster = cluster,
+                Chain = chain
             },
             Id = NextMessageId()
         };

--- a/Runtime/codebase/SolanaMobileStack/MobileWalletAdapterClient.cs
+++ b/Runtime/codebase/SolanaMobileStack/MobileWalletAdapterClient.cs
@@ -34,15 +34,22 @@ public class MobileWalletAdapterClient: JsonRpc20Client, IAdapterOperations, IMe
         return SendRequest<AuthorizationResult>(request);
     }
 
-    public Task<AuthorizationResult> Reauthorize(Uri identityUri, Uri iconUri, string identityName, string authToken)
+    public Task<AuthorizationResult> Reauthorize(Uri identityUri, Uri iconUri, string identityName, string authToken, string cluster = null, string chain = null)
     {
+        // MWA 2.0 deprecated the standalone `reauthorize` method in favour of `authorize`
+        // carrying an `auth_token`. The `chain` MUST be re-sent here: when it is absent the
+        // wallet (e.g. Seeker Seed Vault) defaults the re-established session to
+        // solana:mainnet, producing a "Network mismatch" at sign time even though the
+        // original authorize was devnet. When the chain matches the token's binding the
+        // wallet silently reuses the existing auth_token (no extra user prompt).
         var request = PrepareAuthRequest(
             identityUri,
-            iconUri, 
-            identityName, 
-            null,
-            "reauthorize");
-        
+            iconUri,
+            identityName,
+            cluster,
+            "authorize",
+            chain);
+
         request.Params.AuthToken = authToken;
 
         return SendRequest<AuthorizationResult>(request);

--- a/Runtime/codebase/SolanaMobileStack/SolanaMobileWalletAdapter.cs
+++ b/Runtime/codebase/SolanaMobileStack/SolanaMobileWalletAdapter.cs
@@ -189,7 +189,8 @@ namespace Solana.Unity.SDK
             // operation in one session, so only the operation itself prompts.
             if (!_authToken.IsNullOrEmpty())
             {
-                var reauthorize = new ReauthorizeOperation(_walletOptions, _authToken);
+                var reauthorize = new ReauthorizeOperation(
+                    _walletOptions, _authToken, RPCNameMap[(int)RpcCluster], ChainNameMap[(int)RpcCluster]);
                 using (var scenario = await CreateTargetedScenario())
                 {
                     var actions = reauthorize.BuildActions();
@@ -609,13 +610,17 @@ internal sealed class ReauthorizeOperation
 {
     private readonly SolanaMobileWalletAdapterOptions _opts;
     private readonly string _authToken;
-    
+    private readonly string _cluster;
+    private readonly string _chain;
+
     public AuthorizationResult Authorization { get; private set; }
 
-    public ReauthorizeOperation(SolanaMobileWalletAdapterOptions opts, string authToken)
+    public ReauthorizeOperation(SolanaMobileWalletAdapterOptions opts, string authToken, string cluster = null, string chain = null)
     {
         _opts = opts;
         _authToken = authToken;
+        _cluster = cluster;
+        _chain = chain;
     }
 
     public List<Action<IAdapterOperations>> BuildActions()
@@ -627,7 +632,7 @@ internal sealed class ReauthorizeOperation
                 Authorization = await client.Reauthorize(
                     new Uri(_opts.identityUri),
                     new Uri(_opts.iconUri, UriKind.Relative),
-                    _opts.name, _authToken);
+                    _opts.name, _authToken, _cluster, _chain);
             }
         };
     }

--- a/Runtime/codebase/SolanaMobileStack/SolanaMobileWalletAdapter.cs
+++ b/Runtime/codebase/SolanaMobileStack/SolanaMobileWalletAdapter.cs
@@ -40,6 +40,17 @@ namespace Solana.Unity.SDK
         public event Action OnWalletDisconnected;
         public event Action OnWalletReconnected;
 
+        // CAIP-2 chain identifiers for MWA 2.0 wallets (e.g. Seeker Seed Vault).
+        // Keyed to match RpcCluster / RPCNameMap. LocalNet has no standard CAIP-2
+        // value, so it maps to null and only the legacy "cluster" field is sent.
+        private static readonly Dictionary<int, string> ChainNameMap = new ()
+        {
+            { 0, "solana:mainnet" },
+            { 1, "solana:devnet" },
+            { 2, "solana:testnet" },
+            { 3, null },
+        };
+
         public SolanaMobileWalletAdapter(
             SolanaMobileWalletAdapterOptions solanaWalletOptions,
             RpcCluster rpcCluster = RpcCluster.DevNet, 
@@ -134,6 +145,7 @@ namespace Solana.Unity.SDK
             AuthorizationResult authorization = null;
             var localAssociationScenario = new LocalAssociationScenario();
             var cluster = RPCNameMap[(int)RpcCluster];
+            var chain = ChainNameMap[(int)RpcCluster];
             var result = await localAssociationScenario.StartAndExecute(
                 new List<Action<IAdapterOperations>>
                 {
@@ -142,7 +154,7 @@ namespace Solana.Unity.SDK
                         authorization = await client.Authorize(
                             new Uri(_walletOptions.identityUri),
                             new Uri(_walletOptions.iconUri, UriKind.Relative),
-                            _walletOptions.name, cluster);
+                            _walletOptions.name, cluster, chain);
                     }
                 }
             );
@@ -182,6 +194,7 @@ namespace Solana.Unity.SDK
                 _authToken = PlayerPrefs.GetString(PrefKeyAuthToken, null);
 
             var cluster = RPCNameMap[(int)RpcCluster];
+            var chain = ChainNameMap[(int)RpcCluster];
             SignedResult res = null;
             var localAssociationScenario = new LocalAssociationScenario();
             AuthorizationResult authorization = null;
@@ -195,7 +208,7 @@ namespace Solana.Unity.SDK
                             authorization = await client.Authorize(
                                 new Uri(_walletOptions.identityUri),
                                 new Uri(_walletOptions.iconUri, UriKind.Relative),
-                                _walletOptions.name, cluster);
+                                _walletOptions.name, cluster, chain);
                         }
                         else
                         {
@@ -344,6 +357,7 @@ namespace Solana.Unity.SDK
             var localAssociationScenario = new LocalAssociationScenario();
             AuthorizationResult authorization = null;
             var cluster = RPCNameMap[(int)RpcCluster];
+            var chain = ChainNameMap[(int)RpcCluster];
             var result = await localAssociationScenario.StartAndExecute(
                 new List<Action<IAdapterOperations>>
                 {
@@ -354,7 +368,7 @@ namespace Solana.Unity.SDK
                             authorization = await client.Authorize(
                                 new Uri(_walletOptions.identityUri),
                                 new Uri(_walletOptions.iconUri, UriKind.Relative),
-                                _walletOptions.name, cluster);
+                                _walletOptions.name, cluster, chain);
                         }
                         else
                         {

--- a/Runtime/codebase/SolanaMobileStack/SolanaMobileWalletAdapter.cs
+++ b/Runtime/codebase/SolanaMobileStack/SolanaMobileWalletAdapter.cs
@@ -27,7 +27,16 @@ namespace Solana.Unity.SDK
     {
         private const string PrefKeyPublicKey = "solana_sdk.mwa.public_key";
         private const string PrefKeyAuthToken = "solana_sdk.mwa.auth_token";
-        
+        private const string PrefKeyAuthCacheVersion = "solana_sdk.mwa.auth_cache_version";
+
+        // Bump whenever a change alters the meaning of a cached authorization.
+        // v2 introduces the CAIP-2 `chain` fix: cached tokens minted before it may
+        // have been authorized as mainnet (MWA 2.0 wallets default to mainnet when
+        // `chain` is absent), and reauthorize does not re-send `chain`. On a version
+        // mismatch we drop the cache so the next login performs a fresh authorize.
+        private const int AuthCacheVersion = 2;
+
+
         private readonly SolanaMobileWalletAdapterOptions _walletOptions;
         
         private Transaction _currentTransaction;
@@ -65,6 +74,21 @@ namespace Solana.Unity.SDK
                 throw new Exception("SolanaMobileWalletAdapter can only be used on Android");
             }
             MigrateLegacyPrefKeys();
+            InvalidateStaleAuthCache();
+        }
+
+        // Clears cached credentials when they predate the current authorization
+        // semantics, so upgraded users self-heal instead of staying on a stale
+        // (possibly mainnet-defaulted) session until a manual disconnect.
+        private static void InvalidateStaleAuthCache()
+        {
+            if (PlayerPrefs.GetInt(PrefKeyAuthCacheVersion, 0) == AuthCacheVersion)
+                return;
+
+            PlayerPrefs.DeleteKey(PrefKeyPublicKey);
+            PlayerPrefs.DeleteKey(PrefKeyAuthToken);
+            PlayerPrefs.SetInt(PrefKeyAuthCacheVersion, AuthCacheVersion);
+            PlayerPrefs.Save();
         }
 
         private static void MigrateLegacyPrefKeys()

--- a/Tests/EditMode/Contracts/IAdapterOperationsContractTests.cs
+++ b/Tests/EditMode/Contracts/IAdapterOperationsContractTests.cs
@@ -46,8 +46,8 @@ namespace Solana.Unity.SDK.Tests.EditMode.Contracts
             Assert.IsNotNull(method, "IAdapterOperations.Authorize must exist");
             Assert.AreEqual(typeof(Task<AuthorizationResult>), method.ReturnType,
                 "Authorize must return Task<AuthorizationResult>");
-            Assert.IsTrue(HasParams(method, typeof(Uri), typeof(Uri), typeof(string), typeof(string)),
-                "Authorize params must be (Uri identityUri, Uri iconUri, string identityName, string rpcCluster)");
+            Assert.IsTrue(HasParams(method, typeof(Uri), typeof(Uri), typeof(string), typeof(string), typeof(string)),
+                "Authorize params must be (Uri identityUri, Uri iconUri, string identityName, string rpcCluster, string chain)");
         }
 
         

--- a/Tests/EditMode/Contracts/IAdapterOperationsContractTests.cs
+++ b/Tests/EditMode/Contracts/IAdapterOperationsContractTests.cs
@@ -60,8 +60,8 @@ namespace Solana.Unity.SDK.Tests.EditMode.Contracts
             Assert.IsNotNull(method, "IAdapterOperations.Reauthorize must exist");
             Assert.AreEqual(typeof(Task<AuthorizationResult>), method.ReturnType,
                 "Reauthorize must return Task<AuthorizationResult>");
-            Assert.IsTrue(HasParams(method, typeof(Uri), typeof(Uri), typeof(string), typeof(string)),
-                "Reauthorize params must be (Uri identityUri, Uri iconUri, string identityName, string authToken)");
+            Assert.IsTrue(HasParams(method, typeof(Uri), typeof(Uri), typeof(string), typeof(string), typeof(string), typeof(string)),
+                "Reauthorize params must be (Uri identityUri, Uri iconUri, string identityName, string authToken, string rpcCluster, string chain)");
         }
 
         

--- a/Tests/EditMode/MwaClient/MobileWalletAdapterClientTests.cs
+++ b/Tests/EditMode/MwaClient/MobileWalletAdapterClientTests.cs
@@ -210,8 +210,10 @@ namespace Solana.Unity.SDK.Tests.EditMode.MwaClient
        
         // Reauthorize
         [Test]
-        public void Reauthorize_SendsJsonRpc_WithCorrectMethod()
+        public void Reauthorize_SendsJsonRpc_AsAuthorizeWithAuthToken()
         {
+            // MWA 2.0 deprecated the standalone `reauthorize` method; reauthorization is
+            // performed via `authorize` carrying an auth_token.
             // Arrange
             var identityUri = new Uri("https://example.com");
             const string authToken = "test-auth-token-abc123";
@@ -221,8 +223,8 @@ namespace Solana.Unity.SDK.Tests.EditMode.MwaClient
 
             // Assert
             var request = DecodeLastRequest();
-            Assert.AreEqual("reauthorize", request.Method,
-                "Method must be 'reauthorize'");
+            Assert.AreEqual("authorize", request.Method,
+                "Method must be 'authorize' (MWA 2.0 reauthorize-via-authorize)");
         }
 
         [Test]
@@ -239,6 +241,25 @@ namespace Solana.Unity.SDK.Tests.EditMode.MwaClient
             var request = DecodeLastRequest();
             Assert.AreEqual(authToken, request.Params.AuthToken,
                 "Params.AuthToken must match the supplied auth token");
+        }
+
+        [Test]
+        public void Reauthorize_SendsJsonRpc_WithChain()
+        {
+            // The chain MUST be forwarded on reauthorize, or the wallet defaults the
+            // re-established session to solana:mainnet (Network mismatch at sign time).
+            // Arrange
+            var identityUri = new Uri("https://example.com");
+            const string authToken = "test-auth-token-abc123";
+            const string chain = "solana:devnet";
+
+            // Act
+            _ = _client.Reauthorize(identityUri, null, "TestApp", authToken, "devnet", chain);
+
+            // Assert
+            var request = DecodeLastRequest();
+            Assert.AreEqual(chain, request.Params.Chain,
+                "Params.Chain must match the supplied CAIP-2 chain string on reauthorize");
         }
     }
 }


### PR DESCRIPTION
## Summary

Mobile Wallet Adapter 2.0 replaced the legacy `cluster` parameter with a `chain` parameter using CAIP-2 identifiers (`solana:mainnet` / `solana:devnet` / `solana:testnet`). MWA 2.0 wallets — notably the **Seeker Seed Vault** — **ignore the legacy `cluster` field entirely and default to `solana:mainnet` when `chain` is absent.**

Because `SolanaMobileWalletAdapter` only sent `cluster`, dApps targeting devnet/testnet on these wallets had their session treated as **mainnet**, producing a **"Network mismatch"** error at sign time:

> Your current network is set to devnet, but this transaction is for mainnet. Switch to the correct network before signing.

## Fix

Send the CAIP-2 `chain` field (derived from `RpcCluster`) on the `authorize` request, alongside the existing `cluster` field.

- `JsonRequest` — add serialized `chain` property
- `IAdapterOperations` / `MobileWalletAdapterClient` — thread an optional `chain` argument through `Authorize`
- `SolanaMobileWalletAdapter` — map `RpcCluster` → CAIP-2 (`ChainNameMap`) and pass `chain` on authorize in `Login`, `SignAllTransactions`, and `SignMessage`
- `Tests` — update the `IAdapterOperations` contract test for the new signature

`LocalNet` has no standard CAIP-2 value, so it maps to `null` and (via `NullValueHandling.Ignore`) only the legacy `cluster` field is sent for it.

## Backward compatibility

Fully backward-compatible with MWA 1.x wallets (e.g. older Phantom / Solflare):

- The legacy `cluster` field is **still sent, unchanged** (`mainnet-beta` / `devnet` / `testnet` from `RPCNameMap`). 1.x wallets read it exactly as before and ignore the unknown `chain` field (standard JSON-RPC: unrecognized params are dropped, not rejected).
- `chain` is **additive** and uses `NullValueHandling.Ignore`, so for `LocalNet` the request is byte-identical to the previous behaviour.
- On Android all MWA wallets share this path: 1.x wallets consume `cluster`, 2.0 wallets (Seed Vault, newer Phantom/Solflare) consume `chain`. Sending both is the migration approach described in the [MWA 2.0 spec](https://solana-mobile.github.io/mobile-wallet-adapter/spec/spec.html), which retains `cluster` for backward compatibility.

## Self-healing for existing installs

With `keepConnectionAlive`, a token authorized **before** this fix is reused via `Reauthorize` (which does not carry `chain`), so an upgraded user could remain network-mismatched until a manual disconnect. To avoid that, an auth-cache version (`AuthCacheVersion = 2`) is added: on startup, if the stored version doesn't match, the cached public key + auth token are cleared once so the next `Login` performs a fresh `Authorize(cluster, chain)` on the correct network. New installs are unaffected.

## Testing

Verified on a physical **Seeker** with **Seed Vault** against a devnet dApp:
- **Before:** authorize succeeded but every sign failed with "Network mismatch" (session treated as mainnet).
- **After:** the wallet establishes a **devnet** session and transactions sign and submit successfully.

`solana:devnet` matches the value used by the official `@solana-mobile` React Native SDK and the MWA 2.0 spec `chain` parameter.

Fixes #287


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for optional CAIP-2 chain identifiers in authorization operations to improve compatibility with MWA 2.0 wallets and prevent network mismatches during sign operations.

* **Tests**
  * Expanded test coverage to verify chain parameter handling in authorization and reauthorization flows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->